### PR TITLE
增加一项配置，可以自动清除对话上下文中，拼接在用户输入中的长期记忆

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -58,6 +58,13 @@
         "type":"int",
         "default":3
     },
+    "contexts_memory_len": {
+        "description":"历史上下文中保留的长期记忆数量",
+        "type":"int",
+        "hint":"小于0表示完全保留，大于等于0表示保留最新的对应条",
+        "obvious_hint":true,
+        "default":0
+    },
     "long_memory_prompt":{
         "description":"对话总结提示词",
         "type":"string",


### PR DESCRIPTION
增加一项配置：
contexts_memory_len   int
历史上下文中保留的长期记忆数量
小于0表示完全保留历史上下文中的长期记忆
大于等于0表示保留最新int条长期记忆

当前开发版本，长期记忆会拼接在用户输入中，同时存储在对话上下文中
在较长上下文的对话中，上下文历史中携带大量的长期记忆，并且一部分记忆可能出现频率较高，生成内容重复概率变大
新增的配置可以限制上下文历史中，长期记忆的数量，可以有效改善这一情况