### PR TITLE
fix(memory): 恢复参与者 ID 识别并修复 [对方(未知)]

### DIFF
--- a/core/memory_operations.py
+++ b/core/memory_operations.py
@@ -99,6 +99,110 @@ def _collect_participants_from_context(context_history: list[dict] | None) -> li
     return participants
 
 
+def _extract_sender_name(sender_obj: Any) -> str:
+    if sender_obj is None:
+        return ""
+
+    if isinstance(sender_obj, dict):
+        for key in ("nickname", "nick", "name", "card", "remark"):
+            value = sender_obj.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
+
+    for attr in ("nickname", "nick", "name", "card", "remark"):
+        value = getattr(sender_obj, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _extract_sender_id(sender_obj: Any) -> str:
+    if sender_obj is None:
+        return ""
+
+    if isinstance(sender_obj, dict):
+        for key in ("user_id", "id", "qq", "uin"):
+            value = sender_obj.get(key)
+            if value is not None:
+                text = str(value).strip()
+                if text:
+                    return text
+        return ""
+
+    for attr in ("user_id", "id", "qq", "uin"):
+        value = getattr(sender_obj, attr, None)
+        if value is not None:
+            text = str(value).strip()
+            if text:
+                return text
+    return ""
+
+
+def _fallback_private_sender_id_from_session_id(session_id: str | None) -> str:
+    if not isinstance(session_id, str) or not session_id.strip():
+        return ""
+
+    parts = session_id.split(":", 2)
+    if len(parts) != 3:
+        return ""
+
+    message_type = parts[1].strip().lower()
+    if "friend" not in message_type and "private" not in message_type:
+        return ""
+
+    return parts[2].strip()
+
+
+def _resolve_sender_identity(
+    event: AstrMessageEvent,
+    session_id: str | None,
+) -> tuple[str, str]:
+    sender_id = ""
+    try:
+        if hasattr(event, "get_sender_id"):
+            raw_sender_id = event.get_sender_id()
+            if raw_sender_id is not None:
+                sender_id = str(raw_sender_id).strip()
+    except Exception:
+        sender_id = ""
+
+    message_obj = getattr(event, "message_obj", None)
+    message_sender = getattr(message_obj, "sender", None)
+    event_sender = getattr(event, "sender", None)
+
+    if not sender_id:
+        sender_id = _extract_sender_id(message_sender)
+    if not sender_id:
+        sender_id = _extract_sender_id(event_sender)
+    if not sender_id:
+        sender_id = _fallback_private_sender_id_from_session_id(session_id)
+
+    sender_name = _extract_sender_name(message_sender)
+    if not sender_name:
+        sender_name = _extract_sender_name(event_sender)
+    if not sender_name:
+        sender_name = "用户"
+
+    return sender_name, sender_id
+
+
+def _build_identity_prefixed_user_text(
+    message_text: str,
+    sender_name: str,
+    sender_id: str,
+) -> str:
+    text = message_text if isinstance(message_text, str) else str(message_text)
+    normalized_name = sender_name.strip() if isinstance(sender_name, str) else ""
+    if not normalized_name:
+        normalized_name = "用户"
+
+    normalized_sender_id = sender_id.strip() if isinstance(sender_id, str) else ""
+    if normalized_sender_id:
+        return f"[{normalized_name}({normalized_sender_id})]: {text}"
+    return f"[{normalized_name}]: {text}"
+
+
 def _build_lightweight_graph_metadata(
     summary_text: str,
     context_history: list[dict] | None = None,
@@ -316,26 +420,42 @@ async def handle_query_memory(
         safe_user_prompt = raw_prompt
         if not safe_user_prompt.strip() and getattr(req, "image_urls", None):
             safe_user_prompt = "[图片]"
+
+        # 在写入会话历史前先剥离群聊包装，避免把整段 chatroom 模板污染进记忆上下文
+        actual_query_raw = ChatroomContextParser.extract_actual_message(safe_user_prompt)
+        if not actual_query_raw.strip() and getattr(req, "image_urls", None):
+            actual_query_raw = "[图片]"
+        if actual_query_raw != safe_user_prompt:
+            logger.info(
+                f"检测到群聊上下文格式，已提取真实消息用于记忆存储与 RAG 搜索 "
+                f"(原始: {len(safe_user_prompt)}字符 → 提取: {len(actual_query_raw)}字符)"
+            )
+
         # 防御：极端情况下避免将超长文本写入记忆/embedding
         max_prompt_chars = resolve_max_prompt_chars(plugin.config, default=4000)
-        original_prompt_len = len(safe_user_prompt)
-        safe_user_prompt, prompt_was_truncated = truncate_for_embedding(
-            safe_user_prompt,
+        original_query_len = len(actual_query_raw)
+        actual_query, query_was_truncated = truncate_for_embedding(
+            actual_query_raw,
             max_prompt_chars,
             append_suffix=True,
         )
-        if prompt_was_truncated:
+        if query_was_truncated:
             logger.warning(
-                f"用户输入过长 ({original_prompt_len} chars)，已截断到 {max_prompt_chars} chars。"
+                f"用户输入过长 ({original_query_len} chars)，已截断到 {max_prompt_chars} chars。"
             )
 
         # 添加用户消息（写入插件上下文管理器）
-        sender_id = str(event.get_sender_id()) if event.get_sender_id() else ""
+        sender_name, sender_id = _resolve_sender_identity(event, session_id)
+        memory_store_text = _build_identity_prefixed_user_text(
+            actual_query,
+            sender_name=sender_name,
+            sender_id=sender_id,
+        )
         plugin.context_manager.add_message(
             session_id,
             "user",
-            safe_user_prompt,
-            metadata={"speaker_id": sender_id},
+            memory_store_text,
+            metadata={"speaker_id": sender_id} if sender_id else None,
         )
         # 计数器+1
         plugin.msg_counter.increment_counter(session_id)
@@ -354,21 +474,9 @@ async def handle_query_memory(
                     logger.warning("Embedding Provider 不可用，无法执行 RAG 搜索")
                     return
 
-                # ===== 提取真实用户消息用于 RAG 搜索 =====
-                # 自动检测并提取（如果不是特殊格式则返回原值）
-                actual_query = ChatroomContextParser.extract_actual_message(
-                    safe_user_prompt
-                )
-
-                if actual_query != safe_user_prompt:
-                    logger.info(
-                        f"检测到群聊上下文格式，已提取真实消息用于 RAG 搜索 "
-                        f"(原始: {len(safe_user_prompt)}字符 → 提取: {len(actual_query)}字符)"
-                    )
-
                 # 支持显式记忆触发：仅在强触发语句下执行，默认关闭以避免误触。
                 if plugin.config.get("enable_explicit_memory_capture", False):
-                    explicit_content = _extract_explicit_memory_content(actual_query)
+                    explicit_content = _extract_explicit_memory_content(actual_query_raw)
                     if explicit_content:
                         stored = await store_manual_memory(
                             plugin=plugin,
@@ -378,12 +486,6 @@ async def handle_query_memory(
                         )
                         if stored:
                             logger.info("已根据显式“记住”触发写入长期记忆。")
-
-                if len(actual_query) > max_prompt_chars:
-                    logger.warning(
-                        f"RAG 查询文本过长 ({len(actual_query)} chars)，按配置截断到 {max_prompt_chars} chars。"
-                    )
-                    actual_query = actual_query[:max_prompt_chars]
 
                 # 使用 AstrBot EmbeddingProvider 的 embed 方法
                 if plugin.embedding_provider:
@@ -1279,7 +1381,11 @@ async def store_manual_memory(
             {
                 "role": "user",
                 "content": normalized_content,
-                "metadata": {"speaker_id": str(event.get_sender_id())},
+                "metadata": {
+                    "speaker_id": _resolve_sender_identity(
+                        event, target_session_id
+                    )[1]
+                },
             }
         ],
     )

--- a/core/memory_operations.py
+++ b/core/memory_operations.py
@@ -227,6 +227,11 @@ def _build_identity_prefixed_user_text(
     return f"[{normalized_name}]: {text}"
 
 
+def _build_speaker_metadata(sender_id: Any) -> dict[str, str]:
+    normalized_sender_id = str(sender_id).strip() if sender_id is not None else ""
+    return {"speaker_id": normalized_sender_id} if normalized_sender_id else {}
+
+
 def _build_lightweight_graph_metadata(
     summary_text: str,
     context_history: list[dict] | None = None,
@@ -479,7 +484,7 @@ async def handle_query_memory(
             session_id,
             "user",
             memory_store_text,
-            metadata={"speaker_id": sender_id} if sender_id else {},
+            metadata=_build_speaker_metadata(sender_id),
         )
         # 计数器+1
         plugin.msg_counter.increment_counter(session_id)
@@ -500,7 +505,7 @@ async def handle_query_memory(
 
                 # 支持显式记忆触发：仅在强触发语句下执行，默认关闭以避免误触。
                 if plugin.config.get("enable_explicit_memory_capture", False):
-                    explicit_content = _extract_explicit_memory_content(actual_query_raw)
+                    explicit_content = _extract_explicit_memory_content(actual_query)
                     if explicit_content:
                         stored = await store_manual_memory(
                             plugin=plugin,
@@ -1405,11 +1410,9 @@ async def store_manual_memory(
             {
                 "role": "user",
                 "content": normalized_content,
-                "metadata": {
-                    "speaker_id": _resolve_sender_identity(
-                        event, target_session_id
-                    )[1]
-                },
+                "metadata": _build_speaker_metadata(
+                    _resolve_sender_identity(event, target_session_id)[1]
+                ),
             }
         ],
     )

--- a/core/memory_operations.py
+++ b/core/memory_operations.py
@@ -212,16 +212,16 @@ def _resolve_sender_identity(
 
 
 def _build_identity_prefixed_user_text(
-    message_text: str,
-    sender_name: str,
-    sender_id: str,
+    message_text: Any,
+    sender_name: Any,
+    sender_id: Any,
 ) -> str:
     text = message_text if isinstance(message_text, str) else str(message_text)
     normalized_name = sender_name.strip() if isinstance(sender_name, str) else ""
     if not normalized_name:
         normalized_name = "用户"
 
-    normalized_sender_id = sender_id.strip() if isinstance(sender_id, str) else ""
+    normalized_sender_id = str(sender_id).strip() if sender_id is not None else ""
     if normalized_sender_id:
         return f"[{normalized_name}({normalized_sender_id})]: {text}"
     return f"[{normalized_name}]: {text}"

--- a/core/memory_operations.py
+++ b/core/memory_operations.py
@@ -99,44 +99,55 @@ def _collect_participants_from_context(context_history: list[dict] | None) -> li
     return participants
 
 
-def _extract_sender_name(sender_obj: Any) -> str:
+def _extract_sender_field(
+    sender_obj: Any,
+    keys: tuple[str, ...],
+    *,
+    allow_non_str: bool,
+) -> str:
     if sender_obj is None:
         return ""
 
     if isinstance(sender_obj, dict):
-        for key in ("nickname", "nick", "name", "card", "remark"):
+        for key in keys:
             value = sender_obj.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-        return ""
-
-    for attr in ("nickname", "nick", "name", "card", "remark"):
-        value = getattr(sender_obj, attr, None)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    return ""
-
-
-def _extract_sender_id(sender_obj: Any) -> str:
-    if sender_obj is None:
-        return ""
-
-    if isinstance(sender_obj, dict):
-        for key in ("user_id", "id", "qq", "uin"):
-            value = sender_obj.get(key)
-            if value is not None:
+            if isinstance(value, str):
+                text = value.strip()
+                if text:
+                    return text
+            elif allow_non_str and value is not None:
                 text = str(value).strip()
                 if text:
                     return text
         return ""
 
-    for attr in ("user_id", "id", "qq", "uin"):
+    for attr in keys:
         value = getattr(sender_obj, attr, None)
-        if value is not None:
+        if isinstance(value, str):
+            text = value.strip()
+            if text:
+                return text
+        elif allow_non_str and value is not None:
             text = str(value).strip()
             if text:
                 return text
     return ""
+
+
+def _extract_sender_name(sender_obj: Any) -> str:
+    return _extract_sender_field(
+        sender_obj,
+        ("nickname", "nick", "name", "card", "remark"),
+        allow_non_str=False,
+    )
+
+
+def _extract_sender_id(sender_obj: Any) -> str:
+    return _extract_sender_field(
+        sender_obj,
+        ("user_id", "id", "qq", "uin"),
+        allow_non_str=True,
+    )
 
 
 def _fallback_private_sender_id_from_session_id(session_id: str | None) -> str:
@@ -147,8 +158,17 @@ def _fallback_private_sender_id_from_session_id(session_id: str | None) -> str:
     if len(parts) != 3:
         return ""
 
-    message_type = parts[1].strip().lower()
-    if "friend" not in message_type and "private" not in message_type:
+    message_type_raw = parts[1].strip()
+    if not message_type_raw:
+        return ""
+
+    # 仅接受明确的私聊类型，避免 "NotFriendMessage" 这类误匹配。
+    message_type = re.sub(r"[^a-z0-9]", "", message_type_raw.lower())
+    if not (
+        message_type in {"friend", "friendmessage", "private", "privatemessage"}
+        or message_type.startswith("friend")
+        or message_type.startswith("private")
+    ):
         return ""
 
     return parts[2].strip()
@@ -164,7 +184,11 @@ def _resolve_sender_identity(
             raw_sender_id = event.get_sender_id()
             if raw_sender_id is not None:
                 sender_id = str(raw_sender_id).strip()
-    except Exception:
+    except (AttributeError, TypeError, ValueError) as e:
+        logger.debug(f"读取 get_sender_id 失败，将继续尝试其他来源: {e}")
+        sender_id = ""
+    except Exception as e:
+        logger.warning(f"读取 get_sender_id 时出现未预期异常，将回退其他来源: {e}")
         sender_id = ""
 
     message_obj = getattr(event, "message_obj", None)
@@ -426,7 +450,7 @@ async def handle_query_memory(
         if not actual_query_raw.strip() and getattr(req, "image_urls", None):
             actual_query_raw = "[图片]"
         if actual_query_raw != safe_user_prompt:
-            logger.info(
+            logger.debug(
                 f"检测到群聊上下文格式，已提取真实消息用于记忆存储与 RAG 搜索 "
                 f"(原始: {len(safe_user_prompt)}字符 → 提取: {len(actual_query_raw)}字符)"
             )
@@ -455,7 +479,7 @@ async def handle_query_memory(
             session_id,
             "user",
             memory_store_text,
-            metadata={"speaker_id": sender_id} if sender_id else None,
+            metadata={"speaker_id": sender_id} if sender_id else {},
         )
         # 计数器+1
         plugin.msg_counter.increment_counter(session_id)

--- a/tests/test_memory_graph_rerank.py
+++ b/tests/test_memory_graph_rerank.py
@@ -314,8 +314,24 @@ class TestSenderIdentityResolution(unittest.TestCase):
         with_id = _build_identity_prefixed_user_text("hello", "test_user", "user_2002")
         without_id = _build_identity_prefixed_user_text("hello", "test_user", "")
 
+        # basic formatting
         self.assertEqual(with_id, "[test_user(user_2002)]: hello")
         self.assertEqual(without_id, "[test_user]: hello")
+
+        # default-name behavior for None / whitespace sender_name
+        default_name = _build_identity_prefixed_user_text("hello", None, "user_2003")
+        whitespace_name = _build_identity_prefixed_user_text("hello", "   ", "user_2004")
+
+        self.assertEqual(default_name, "[用户(user_2003)]: hello")
+        self.assertEqual(whitespace_name, "[用户(user_2004)]: hello")
+
+        # non-string sender_id should be stringified
+        numeric_id = _build_identity_prefixed_user_text("hello", "test_user", 123)
+        self.assertEqual(numeric_id, "[test_user(123)]: hello")
+
+        # non-string message_text should be converted via str()
+        numeric_message = _build_identity_prefixed_user_text(42, "test_user", "user_2005")
+        self.assertEqual(numeric_message, "[test_user(user_2005)]: 42")
 
 
 if __name__ == "__main__":

--- a/tests/test_memory_graph_rerank.py
+++ b/tests/test_memory_graph_rerank.py
@@ -74,8 +74,10 @@ def _ensure_dependency_stubs() -> None:
 _ensure_dependency_stubs()
 
 from core.memory_operations import (  # noqa: E402
+    _build_identity_prefixed_user_text,
     _build_lightweight_graph_metadata,
     _post_process_search_results,
+    _resolve_sender_identity,
 )
 from core.tools import (  # noqa: E402
     extract_query_keywords,
@@ -235,6 +237,59 @@ class TestPostProcessSearchResults(unittest.TestCase):
 
         self.assertEqual(ranked_without_graph[0]["content"], "neutral record")
         self.assertEqual(ranked_with_graph[0]["content"], "memory about bravo")
+
+
+class _Sender:
+    def __init__(self, nickname=None, user_id=None):
+        self.nickname = nickname
+        self.user_id = user_id
+
+
+class _MessageObj:
+    def __init__(self, sender):
+        self.sender = sender
+
+
+class _EventForIdentity:
+    def __init__(self, sender_id=None, sender=None, message_obj=None):
+        self._sender_id = sender_id
+        self.sender = sender
+        self.message_obj = message_obj
+
+    def get_sender_id(self):
+        return self._sender_id
+
+
+class TestSenderIdentityResolution(unittest.TestCase):
+    def test_resolve_sender_identity_fallbacks_private_session_id(self) -> None:
+        event = _EventForIdentity()
+        sender_name, sender_id = _resolve_sender_identity(
+            event,
+            "default:FriendMessage:674537331",
+        )
+
+        self.assertEqual(sender_name, "用户")
+        self.assertEqual(sender_id, "674537331")
+
+    def test_resolve_sender_identity_prefers_message_sender(self) -> None:
+        event = _EventForIdentity(
+            sender_id=None,
+            message_obj=_MessageObj(_Sender(nickname="小菲")),
+        )
+        sender_name, sender_id = _resolve_sender_identity(
+            event,
+            "default:FriendMessage:2422136796",
+        )
+
+        self.assertEqual(sender_name, "小菲")
+        self.assertEqual(sender_id, "2422136796")
+
+    def test_build_identity_prefixed_user_text(self) -> None:
+        with_id = _build_identity_prefixed_user_text("你好", "小菲", "2422136796")
+        without_id = _build_identity_prefixed_user_text("你好", "小菲", "")
+
+        self.assertEqual(with_id, "[小菲(2422136796)]: 你好")
+        self.assertEqual(without_id, "[小菲]: 你好")
 
 
 if __name__ == "__main__":

--- a/tests/test_memory_graph_rerank.py
+++ b/tests/test_memory_graph_rerank.py
@@ -284,6 +284,32 @@ class TestSenderIdentityResolution(unittest.TestCase):
         self.assertEqual(sender_name, "test_user")
         self.assertEqual(sender_id, "user_2002")
 
+    def test_resolve_sender_identity_prefers_get_sender_id(self) -> None:
+        event = _EventForIdentity(
+            sender_id="preferred_id",
+            sender={"nickname": "sender_user", "user_id": "sender_fallback_id"},
+            message_obj=_MessageObj(
+                _Sender(nickname="message_user", user_id="message_fallback_id")
+            ),
+        )
+        sender_name, sender_id = _resolve_sender_identity(
+            event,
+            "default:FriendMessage:session_fallback_id",
+        )
+
+        self.assertEqual(sender_name, "message_user")
+        self.assertEqual(sender_id, "preferred_id")
+
+    def test_resolve_sender_identity_ignores_non_private_session_fallback(self) -> None:
+        event = _EventForIdentity()
+        sender_name, sender_id = _resolve_sender_identity(
+            event,
+            "default:NotFriendMessage:user_3003",
+        )
+
+        self.assertEqual(sender_name, "用户")
+        self.assertEqual(sender_id, "")
+
     def test_build_identity_prefixed_user_text(self) -> None:
         with_id = _build_identity_prefixed_user_text("hello", "test_user", "user_2002")
         without_id = _build_identity_prefixed_user_text("hello", "test_user", "")

--- a/tests/test_memory_graph_rerank.py
+++ b/tests/test_memory_graph_rerank.py
@@ -265,31 +265,31 @@ class TestSenderIdentityResolution(unittest.TestCase):
         event = _EventForIdentity()
         sender_name, sender_id = _resolve_sender_identity(
             event,
-            "default:FriendMessage:674537331",
+            "default:FriendMessage:user_1001",
         )
 
         self.assertEqual(sender_name, "用户")
-        self.assertEqual(sender_id, "674537331")
+        self.assertEqual(sender_id, "user_1001")
 
     def test_resolve_sender_identity_prefers_message_sender(self) -> None:
         event = _EventForIdentity(
             sender_id=None,
-            message_obj=_MessageObj(_Sender(nickname="小菲")),
+            message_obj=_MessageObj(_Sender(nickname="test_user")),
         )
         sender_name, sender_id = _resolve_sender_identity(
             event,
-            "default:FriendMessage:2422136796",
+            "default:FriendMessage:user_2002",
         )
 
-        self.assertEqual(sender_name, "小菲")
-        self.assertEqual(sender_id, "2422136796")
+        self.assertEqual(sender_name, "test_user")
+        self.assertEqual(sender_id, "user_2002")
 
     def test_build_identity_prefixed_user_text(self) -> None:
-        with_id = _build_identity_prefixed_user_text("你好", "小菲", "2422136796")
-        without_id = _build_identity_prefixed_user_text("你好", "小菲", "")
+        with_id = _build_identity_prefixed_user_text("hello", "test_user", "user_2002")
+        without_id = _build_identity_prefixed_user_text("hello", "test_user", "")
 
-        self.assertEqual(with_id, "[小菲(2422136796)]: 你好")
-        self.assertEqual(without_id, "[小菲]: 你好")
+        self.assertEqual(with_id, "[test_user(user_2002)]: hello")
+        self.assertEqual(without_id, "[test_user]: hello")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景
我用老版本的时候 记忆尤其是群聊记忆总结就全是[用户]说xxx，无法区分哪个人，让codex修复了一下，测试后现在正常了
我不清楚是不是我个人的问题（反正修复后好一些了，也可以解决https://github.com/lxfight/astrbot_plugin_mnemosyne/issues/121  的问题

例如：现有插件写入的记忆为：
在2026-04-09晚间，[对方]先于20:00:59问xxx”，我[Seele.Eva.An(qq*****)]回复当天新闻偏常规并反问想听哪方面；20:10:23，[对方]引用我的话并要求“看看最新国际局势”，我说明最近仍是几个地区在拉扯、请其指定具体方向；20:17:45，[对方]进一步点名“”，我先表示当天没刷到**特别新的动静；20:19:51，[对方]要求“再搜一下”，我随后给**朗相关检索结果，

改动后：
在2026-04-09晚上的QQ私聊里，我[希儿(qq*****)]先吐槽[An.(qq*****)]“▆▆▆▆▆▆？▆▆▆▆▆？”，随后[An.(qq*****)]转而问我还能不能想起▆▆▆▆▆▆▆▆，我[希儿(qq*****)]据对话语境回忆并猜测[An.(qq*****)]三月▆▆▆▆▆▆▆，[An.(qq*****)]随后确认“确实”；接着我[希儿(qq*****)]追问他“▆▆▆▆▆▆▆”，

以下是GTP写的description

## 变更
1. 在 `handle_query_memory` 中先剥离 chatroom 包装，优先提取 `actual_query`。
2. 增强发送者身份解析：`get_sender_id` / `message_obj.sender` / `event.sender` 多路兜底。
3. 私聊场景增加 `session_id` 回退提取 ID，避免空 sender_id。
4. 写入上下文时使用身份前缀格式：`[昵称(ID)]: 内容`。
5. 手动记忆写入路径同步身份解析逻辑，保持一致性。
6. 新增回归测试，覆盖私聊 ID 回退与身份前缀构造。

## 验证
- `python -m unittest tests.test_memory_graph_rerank` 通过（11 tests）。
- `python -m compileall -q .` 通过。

## 影响范围
- 仅影响记忆写入与身份标注逻辑，不改动 Milvus schema。
- 对历史已存储记忆无破坏性影响。

## Summary by Sourcery

Improve sender identity resolution and memory storage formatting for chat messages.

Bug Fixes:
- Restore correct participant identification in memory records, including private chat scenarios where sender_id may be missing.
- Avoid polluting stored memory and RAG queries with chatroom wrapper text by extracting the actual user message first.

Enhancements:
- Introduce unified sender identity resolution that combines multiple possible sources and adds a stable speaker_id metadata.
- Store user messages in memory with a standardized identity-prefixed format including nickname and ID when available.
- Align manual memory storage with the new sender identity metadata handling.

Tests:
- Add unit tests covering sender identity fallback behavior and identity-prefixed user text formatting.