### PR TITLE
保留移除 Mnemosyne 标签时的 AstrBot 消息元数据

### DIFF
--- a/core/tools.py
+++ b/core/tools.py
@@ -105,6 +105,13 @@ def remove_mnemosyne_tags(
     compiled_regex = re.compile(r"<Mnemosyne>.*?</Mnemosyne>", re.DOTALL)
     cleaned_contents: list[dict[str, Any]] = []
 
+    def copy_with_cleaned_content(
+        content_item: dict[str, Any], cleaned_content: Any
+    ) -> dict[str, Any]:
+        cleaned_item = content_item.copy()
+        cleaned_item["content"] = cleaned_content
+        return cleaned_item
+
     if contexts_memory_len == 0:
         for content_item in contents:
             if isinstance(content_item, dict) and content_item.get("role") == "user":
@@ -113,7 +120,9 @@ def remove_mnemosyne_tags(
                 # 只有在 content 为 str 时才需要清理标签。
                 if isinstance(original_text, str):
                     cleaned_text = compiled_regex.sub("", original_text)
-                    cleaned_contents.append({"role": "user", "content": cleaned_text})
+                    cleaned_contents.append(
+                        copy_with_cleaned_content(content_item, cleaned_text)
+                    )
                 else:
                     cleaned_contents.append(content_item)
             else:
@@ -141,14 +150,14 @@ def remove_mnemosyne_tags(
                 # 使用 elif 形成互斥逻辑，避免重复处理
                 if isinstance(original_text, list):
                     # 1. 如果内容是列表（多模态消息），直接保留原样
-                    cleaned_contents.append({"role": "user", "content": original_text})
+                    cleaned_contents.append(content_item)
                 elif isinstance(original_text, str):
                     # 2. 如果内容是字符串，检查是否需要清理标签
                     if compiled_regex.search(original_text):
                         # 内容包含标签，进行清理
                         cleaned_text = compiled_regex.sub(replace_logic, original_text)
                         cleaned_contents.append(
-                            {"role": "user", "content": cleaned_text}
+                            copy_with_cleaned_content(content_item, cleaned_text)
                         )
                     else:
                         # 内容不包含标签，直接保留

--- a/tests/test_memory_graph_rerank.py
+++ b/tests/test_memory_graph_rerank.py
@@ -82,6 +82,7 @@ from core.memory_operations import (  # noqa: E402
 from core.tools import (  # noqa: E402
     extract_query_keywords,
     pack_memory_content,
+    remove_mnemosyne_tags,
     resolve_max_prompt_chars,
     split_memory_content_meta,
     strip_memory_meta,
@@ -132,6 +133,79 @@ class TestMemoryMetaHelpers(unittest.TestCase):
         self.assertEqual(plain, "x" * 8)
         self.assertTrue(suffixed_changed)
         self.assertEqual(suffixed, "x" * 8 + "…(truncated)")
+
+
+class TestRemoveMnemosyneTags(unittest.TestCase):
+    def test_remove_all_tags_preserves_user_message_metadata(self) -> None:
+        message = {
+            "role": "user",
+            "content": "Hello <Mnemosyne>memory</Mnemosyne> world",
+            "_no_save": True,
+            "message_id": "preset-1",
+        }
+
+        cleaned = remove_mnemosyne_tags([message], contexts_memory_len=0)
+
+        self.assertEqual(cleaned[0]["content"], "Hello  world")
+        self.assertTrue(cleaned[0]["_no_save"])
+        self.assertEqual(cleaned[0]["message_id"], "preset-1")
+        self.assertEqual(
+            message["content"], "Hello <Mnemosyne>memory</Mnemosyne> world"
+        )
+
+    def test_remove_all_tags_preserves_metadata_without_tags(self) -> None:
+        message = {
+            "role": "user",
+            "content": "Plain preset message",
+            "_no_save": True,
+            "custom": {"source": "begin_dialogs"},
+        }
+
+        cleaned = remove_mnemosyne_tags([message], contexts_memory_len=0)
+
+        self.assertEqual(cleaned[0]["content"], "Plain preset message")
+        self.assertTrue(cleaned[0]["_no_save"])
+        self.assertEqual(cleaned[0]["custom"], {"source": "begin_dialogs"})
+
+    def test_tag_retention_preserves_metadata_for_cleaned_and_kept_tags(self) -> None:
+        contents = [
+            {
+                "role": "user",
+                "content": "old <Mnemosyne>first</Mnemosyne>",
+                "_no_save": True,
+                "message_id": "old",
+            },
+            {
+                "role": "user",
+                "content": "new <Mnemosyne>second</Mnemosyne>",
+                "_no_save": True,
+                "message_id": "new",
+            },
+        ]
+
+        cleaned = remove_mnemosyne_tags(contents, contexts_memory_len=1)
+
+        self.assertEqual(cleaned[0]["content"], "old ")
+        self.assertTrue(cleaned[0]["_no_save"])
+        self.assertEqual(cleaned[0]["message_id"], "old")
+        self.assertEqual(cleaned[1]["content"], "new <Mnemosyne>second</Mnemosyne>")
+        self.assertTrue(cleaned[1]["_no_save"])
+        self.assertEqual(cleaned[1]["message_id"], "new")
+
+    def test_multimodal_user_message_preserves_metadata(self) -> None:
+        content_parts = [{"type": "text", "text": "hello"}]
+        message = {
+            "role": "user",
+            "content": content_parts,
+            "_no_save": True,
+            "custom": "preserved",
+        }
+
+        cleaned = remove_mnemosyne_tags([message], contexts_memory_len=1)
+
+        self.assertIs(cleaned[0]["content"], content_parts)
+        self.assertTrue(cleaned[0]["_no_save"])
+        self.assertEqual(cleaned[0]["custom"], "preserved")
 
 
 class TestLightweightGraphMetadata(unittest.TestCase):


### PR DESCRIPTION
# 保留移除 Mnemosyne 标签时的 AstrBot 消息元数据

> 本 PR 的代码、测试和说明内容由 GPT-5.5 生成，并已在本地完成验证。

## 概要

这个 PR 修复 `remove_mnemosyne_tags()` 在清理用户消息 `content` 时丢失
AstrBot 消息元数据的问题。

修复后，函数会复制原始 user message dict，并且只替换清理后的
`content` 字段，保留 `_no_save` 等未知字段。

## 问题

Mnemosyne 会在记忆处理前，从 AstrBot 上下文消息中移除
`<Mnemosyne>...</Mnemosyne>` 标签。当前实现中，部分 user message dict
会被重建为：

```python
{"role": "user", "content": cleaned_text}
```

这会丢弃原消息上的其他元数据字段，例如 AstrBot 使用的 `_no_save`。

## 影响

AstrBot 会用 `_no_save` 标记注入的预设对话，例如 persona 的
`begin_dialogs`，避免这些预设消息被写入真实 conversation history。

如果 `_no_save` 在 Mnemosyne 清理标签时丢失，预设 user 消息就可能被持久化
到真实历史里；同时预设 assistant 消息仍会被跳过。长期运行后，这会造成
重复的 user-only 预设对话前缀污染 conversation history。

## 我实际遇到的问题

我是在检查bot的对话数据时发现该问题的，AstrBot persona 的 `begin_dialogs` 会在每轮对话前注入预设上下文；
这些预设消息本来带有 `_no_save`，不应该进入真实会话历史。

但经过 Mnemosyne 的 `remove_mnemosyne_tags()` 处理后，user 预设消息上的
`_no_save` 被丢掉了，于是这些预设 user 消息被保存进 conversation history。
与此同时，assistant 预设消息仍然没有被保存，最终历史里反复出现只有 user
侧的预设对话前缀。

这个现象会让后续上下文和记忆处理看到一段并非真实用户发送的重复历史，
对长期记忆造成污染；清理时也很难只靠内容判断哪些记录是真实对话、哪些是
被错误持久化的预设上下文。

## 修复方式

- 清理字符串 `content` 时，复制原始 message dict，只替换 `content`。
- `contexts_memory_len > 0` 的标签保留路径也使用同样逻辑。
- 多模态 list content 保留原始 message dict，不再重建只包含 `role` 和
  `content` 的新 dict。

标签清理语义保持不变：

- `contexts_memory_len == 0` 仍然移除所有 Mnemosyne 标签。
- `contexts_memory_len > 0` 仍然只保留最新的指定数量标签块。
- 非字符串内容仍然保持原样。

## 兼容性

这个改动只保留原本已经存在于 message dict 上的额外字段，不改变 Mnemosyne
标签匹配、删除或保留逻辑。对于只包含 `role` 和 `content` 的旧消息，行为与
之前一致。

## 验证

已增加回归测试，覆盖 `_no_save` 和其他未知 message metadata 在
`remove_mnemosyne_tags()` 后仍被保留的行为，包括：

- 移除全部标签时保留 metadata。
- 没有标签的普通 user message 保留 metadata。
- `contexts_memory_len > 0` 时，被清理和被保留标签的消息都保留 metadata。
- 多模态 list content 保留 metadata。

本地验证通过：

```bash
python3 -m unittest discover -s tests
python3 -m compileall core tests
```

## Summary by Sourcery

Preserve user message metadata when stripping Mnemosyne tags from AstrBot context messages.

Bug Fixes:
- Ensure remove_mnemosyne_tags() copies and updates only the content field so metadata like _no_save and message identifiers are retained for cleaned user messages, including when contexts_memory_len is zero or greater than zero.
- Keep original metadata intact for multimodal user messages with list-based content when processing Mnemosyne tags.

Tests:
- Add regression tests verifying that remove_mnemosyne_tags() preserves arbitrary user message metadata across different tagging scenarios and for multimodal content.