### PR TITLE
fix: resolve open issues for v2.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ---
 
 [![License](https://img.shields.io/badge/license-Custom-blue.svg)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-v2.0.0-green.svg)](https://github.com/lxfight/astrbot_plugin_mnemosyne)
+[![Version](https://img.shields.io/badge/version-v2.1.7-green.svg)](https://github.com/lxfight/astrbot_plugin_mnemosyne)
 [![QQ Group](https://img.shields.io/badge/QQ群-953245617-blue?style=flat-square&logo=tencent-qq)](https://qm.qq.com/cgi-bin/qm/qr?k=WdyqoP-AOEXqGAN08lOFfVSguF2EmBeO&jump_from=webapi&authKey=tPyfv90TVYSGVhbAhsAZCcSBotJuTTLf03wnn7/lQZPUkWfoQ/J8e9nkAipkOzwh)
 
 </div>
@@ -143,13 +143,23 @@
 </tr>
 <tr>
 <td><code>memory_injection_method</code></td>
-<td>记忆注入方式</td>
+<td>记忆注入方式；独立系统消息可能降低提示词缓存命中率</td>
 <td>user_prompt</td>
 </tr>
 <tr>
 <td><code>memory_injection_position</code></td>
 <td>记忆注入位置（prepend/append）</td>
 <td>prepend</td>
+</tr>
+<tr>
+<td><code>summary_fallback_provider_id</code></td>
+<td>主总结模型失败或返回空内容时使用的备用模型</td>
+<td>空</td>
+</tr>
+<tr>
+<td><code>summary_speaker_mapping_prompt</code></td>
+<td>约束总结中 user、assistant 与第一人称的映射</td>
+<td>内置通用映射</td>
 </tr>
 <tr>
 <td><code>use_personality_filtering</code></td>

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -6,6 +6,13 @@
         "_special":"select_provider",
         "default":""
     },
+    "summary_fallback_provider_id":{
+        "description":"记忆总结备用 LLM 服务商",
+        "type":"string",
+        "hint":"主总结模型调用失败或返回空内容时重试一次。留空表示不启用备用模型",
+        "_special":"select_provider",
+        "default":""
+    },
     "embedding_provider_id":{
         "description":"Embedding 服务提供商",
         "type":"string",
@@ -266,7 +273,7 @@
     "memory_injection_method":{
         "description":"记忆插入方式",
         "type":"string",
-        "hint":"user_prompt 会嵌入到用户消息的最前面，system_prompt会嵌入到系统消息中，insert_system_prompt会向上下文列表中添加一条新的系统消息",
+        "hint":"user_prompt 注入到 LLM 用户提示词，位置由 memory_injection_position 控制；system_prompt 注入到 LLM 系统提示词；insert_system_prompt 会新增一条独立系统消息，可能降低部分模型的提示词缓存命中率",
         "options": ["user_prompt", "system_prompt", "insert_system_prompt"],
         "default": "user_prompt"
     },
@@ -303,10 +310,16 @@
         "hint":"减少模型在总结文本中臆造随机年份/日期",
         "default":true
     },
+    "summary_speaker_mapping_prompt":{
+        "description":"记忆总结说话人映射提示词",
+        "type":"text",
+        "hint":"用于约束 user/assistant 与第一人称的归属。支持 {persona_id}、{session_id}、{sender_id}、{sender_name} 变量；留空可禁用",
+        "default":"说话人映射：assistant 表示当前会话正在运行的人格角色（persona_id={persona_id}），user 表示当前对话用户（sender_name={sender_name}，sender_id={sender_id}，session_id={session_id}）。总结中的“我/我的”只能指 assistant 对应的人格角色；user 发言中的第一人称应改写为用户昵称、用户或其。除非原始对话或人设明确如此自称，不要把 assistant 称为 AI、助手、bot 或模型。"
+    },
     "long_memory_prompt":{
         "description":"对话总结提示词",
         "type":"string",
-        "default":"请基于以下对话内容生成一段连贯的总结性文字，要求：1. 使用单段自然语言表述，不加序号或分点；2. 聚焦提取核心要素，包括但不限于参与者身份（姓名/角色）、核心事件、关键时间节点、特殊需求、争议点及解决方案；3. 保留涉及金额/数量/规格等量化信息；4.不输出多余的解释性内容；5. 用简洁书面语整合信息，确保信息完整准确。注意：避免添加解释性内容，仅客观呈现对话要素的整合结果。6.以AI的第一人称视角记录信息",
+        "default":"请基于以下对话内容生成一段连贯的长期记忆：1. 使用单段自然语言，不加序号或分点；2. 聚焦参与者身份、核心事件、关键时间、特殊需求、争议与解决方案；3. 保留金额、数量、规格等信息；4. 严格遵循说话人映射，不混淆 user 与 assistant 的经历和第一人称；5. 不输出解释或分析过程。",
         "minLength":10,
         "maxLength":1000
     }

--- a/core/constants.py
+++ b/core/constants.py
@@ -15,6 +15,7 @@ DEFAULT_OUTPUT_FIELDS = [
 ]  # 默认查询返回字段
 # 查询记忆条数的上限
 MAX_TOTAL_FETCH_RECORDS = 10000
+SESSION_ID_MAX_LENGTH = 500
 
 # --- 对话上下文相关常量 ---
 DEFAULT_MAX_TURNS = 10  # 短期记忆最大对话轮数（用于总结）

--- a/core/initialization.py
+++ b/core/initialization.py
@@ -33,6 +33,7 @@ from .constants import (
     DEFAULT_EMBEDDING_DIM,
     DEFAULT_OUTPUT_FIELDS,
     PRIMARY_FIELD_NAME,
+    SESSION_ID_MAX_LENGTH,
     VECTOR_FIELD_NAME,
 )
 from .tools import parse_address
@@ -226,9 +227,9 @@ def initialize_config_and_schema(plugin: "Mnemosyne"):
             _build_field_schema(
                 name="session_id",
                 dtype=DataType.VARCHAR,
-                max_length=72,
+                max_length=SESSION_ID_MAX_LENGTH,
                 description="会话ID",
-            ),  # 增加了长度限制
+            ),
             _build_field_schema(
                 name="content",
                 dtype=DataType.VARCHAR,
@@ -765,6 +766,17 @@ def setup_vector_db_collection_and_index(
     # 对于 Milvus，确保索引存在
     db_type = plugin.config.get("vector_db_type", "chroma").lower()
     if db_type == "milvus":
+        manager = getattr(plugin, "milvus_manager", None)
+        if manager and not manager.ensure_varchar_field_max_length(
+            collection_name,
+            "session_id",
+            SESSION_ID_MAX_LENGTH,
+        ):
+            init_logger.warning(
+                f"集合 '{collection_name}' 的 session_id 字段无法自动扩容到 "
+                f"{SESSION_ID_MAX_LENGTH}。长会话 ID 仍可能写入失败；"
+                "请升级 PyMilvus/Milvus 后重载插件，或按故障排查文档迁移集合。"
+            )
         ensure_milvus_index(plugin, collection_name)
 
     init_logger.info(

--- a/core/memory_operations.py
+++ b/core/memory_operations.py
@@ -50,6 +50,15 @@ if TYPE_CHECKING:
 
 logger = LogManager.GetLogger(__name__)
 
+DEFAULT_SUMMARY_SPEAKER_MAPPING_PROMPT = (
+    "说话人映射：assistant 表示当前会话正在运行的人格角色"
+    "（persona_id={persona_id}），user 表示当前对话用户"
+    "（sender_name={sender_name}，sender_id={sender_id}，session_id={session_id}）。"
+    "总结中的“我/我的”只能指 assistant 对应的人格角色；"
+    "user 发言中的第一人称应改写为用户昵称、用户或其。"
+    "除非原始对话或人设明确如此自称，不要把 assistant 称为 AI、助手、bot 或模型。"
+)
+
 
 def _get_vector_db(plugin: "Mnemosyne"):
     """获取当前配置的向量数据库实例。"""
@@ -1100,8 +1109,74 @@ async def _check_summary_prerequisites(plugin: "Mnemosyne", memory_text: str) ->
     return True
 
 
+def _summary_response_has_text(response: Any) -> bool:
+    if isinstance(response, LLMResponse):
+        completion_text = response.completion_text
+    elif isinstance(response, dict):
+        completion_text = response.get("completion_text")
+    else:
+        return False
+    return isinstance(completion_text, str) and bool(completion_text.strip())
+
+
+def _build_summary_speaker_mapping_prompt(
+    plugin: "Mnemosyne",
+    persona_id: str | None,
+    session_id: str,
+    context_history: list[dict] | None,
+) -> str:
+    template = plugin.config.get(
+        "summary_speaker_mapping_prompt",
+        DEFAULT_SUMMARY_SPEAKER_MAPPING_PROMPT,
+    )
+    if not isinstance(template, str) or not template.strip():
+        return ""
+
+    sender_id = "UNKNOWN_USER"
+    sender_name = "用户"
+    for message in reversed(context_history or []):
+        if not isinstance(message, dict) or message.get("role") != "user":
+            continue
+        metadata = message.get("metadata")
+        if isinstance(metadata, dict):
+            candidate_id = metadata.get("speaker_id")
+            if isinstance(candidate_id, str) and candidate_id.strip():
+                sender_id = candidate_id.strip()
+        content = message.get("content")
+        if isinstance(content, str):
+            matched = re.match(r"^\[([^\]()]+)\(([^()]*)\)\]:", content)
+            if matched and matched.group(1).strip():
+                sender_name = matched.group(1).strip()
+        break
+
+    replacements = {
+        "{persona_id}": persona_id or DEFAULT_PERSONA_ON_NONE,
+        "{session_id}": session_id,
+        "{sender_id}": sender_id,
+        "{sender_name}": sender_name,
+    }
+    rendered = template
+    for placeholder, value in replacements.items():
+        rendered = rendered.replace(placeholder, value)
+    return rendered.strip()
+
+
+def _get_current_summary_provider(plugin: "Mnemosyne", session_id: str):
+    if plugin.provider:
+        return plugin.provider
+    try:
+        return plugin.context.get_using_provider(umo=session_id)
+    except TypeError:
+        return plugin.context.get_using_provider()
+
+
 async def _get_summary_llm_response(
-    plugin: "Mnemosyne", memory_text: str
+    plugin: "Mnemosyne",
+    memory_text: str,
+    *,
+    persona_id: str | None = None,
+    session_id: str = "",
+    context_history: list[dict] | None = None,
 ) -> LLMResponse | None:
     """
     请求 LLM 进行记忆总结。
@@ -1114,17 +1189,33 @@ async def _get_summary_llm_response(
         LLMResponse 对象，如果请求失败则为 None。
     """
     # logger = plugin.logger
-    llm_provider = plugin.provider
-    # TODO: 优化LLM Provider获取逻辑，确保在plugin.provider不可用时能正确回退到当前使用的Provider
+    providers: list[tuple[str, Any]] = []
     try:
-        if not llm_provider:
-            # 如果plugin.provider不正确，在这时候，使用当前使用的LLM服务商，避免错误
-            llm_provider = plugin.context.get_using_provider()
-            if not llm_provider:
-                logger.error("无法获取用于总结记忆的 LLM Provider。")
-                return None
+        primary_provider = _get_current_summary_provider(plugin, session_id)
+        if primary_provider:
+            providers.append(("主", primary_provider))
     except Exception as e:
         logger.error(f"获取 LLM Provider 时出错: {e}", exc_info=True)
+
+    fallback_provider_id = plugin.config.get("summary_fallback_provider_id", "")
+    if isinstance(fallback_provider_id, str) and fallback_provider_id.strip():
+        try:
+            fallback_provider = plugin.context.get_provider_by_id(
+                fallback_provider_id.strip()
+            )
+            if fallback_provider and all(
+                fallback_provider is not provider for _, provider in providers
+            ):
+                providers.append(("备用", fallback_provider))
+            elif not fallback_provider:
+                logger.warning(
+                    f"未找到备用总结 Provider: {fallback_provider_id.strip()}"
+                )
+        except Exception as e:
+            logger.error(f"获取备用总结 Provider 时出错: {e}", exc_info=True)
+
+    if not providers:
+        logger.error("无法获取用于总结记忆的 LLM Provider。")
         return None
 
     long_memory_prompt = plugin.config.get(
@@ -1152,16 +1243,38 @@ async def _get_summary_llm_response(
                 }
             )
 
-        # M24 修复: 添加 text_chat 方法的类型忽略
-        llm_response = await llm_provider.text_chat(  # type: ignore
-            prompt=memory_text,
-            contexts=summary_contexts,
-            **summary_llm_config,
+        speaker_mapping = _build_summary_speaker_mapping_prompt(
+            plugin,
+            persona_id,
+            session_id,
+            context_history,
         )
-        logger.debug(f"LLM 总结响应原始数据: {llm_response}")
-        return llm_response
+        if speaker_mapping:
+            summary_contexts.append(
+                {"role": "system", "content": speaker_mapping}
+            )
+
+        for provider_kind, llm_provider in providers:
+            try:
+                llm_response = await llm_provider.text_chat(  # type: ignore
+                    prompt=memory_text,
+                    contexts=summary_contexts,
+                    **summary_llm_config,
+                )
+                logger.debug(
+                    f"{provider_kind} LLM 总结响应原始数据: {llm_response}"
+                )
+                if _summary_response_has_text(llm_response):
+                    return llm_response
+                logger.warning(f"{provider_kind}总结 Provider 返回空内容。")
+            except Exception as e:
+                logger.error(
+                    f"{provider_kind}总结 Provider 请求失败: {e}",
+                    exc_info=True,
+                )
+        return None
     except Exception as e:
-        logger.error(f"LLM 总结请求失败: {e}", exc_info=True)
+        logger.error(f"构造总结请求时失败: {e}", exc_info=True)
         return None
 
 
@@ -1328,7 +1441,13 @@ async def handle_summary_long_memory(
 
     try:
         # 1. 请求 LLM 进行总结
-        llm_response = await _get_summary_llm_response(plugin, memory_text)
+        llm_response = await _get_summary_llm_response(
+            plugin,
+            memory_text,
+            persona_id=persona_id,
+            session_id=session_id,
+            context_history=context_history,
+        )
         if not llm_response:
             return False
 

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -35,11 +35,15 @@ See [Database Options](/en/guide/database) for backend guidance.
 | `num_pairs` | Conversation rounds required before automatic summarization. | `5` |
 | `top_k` | Number of memories returned by retrieval. | `3` |
 | `contexts_memory_len` | Number of long-term memories injected into context. | `3` |
-| `memory_injection_method` | Inject memory into the user prompt or system prompt. | `user_prompt` |
+| `memory_injection_method` | Use the user prompt, the LLM system prompt, or a separate system message. | `user_prompt` |
 | `memory_injection_position` | Inject before or after the active prompt. | `prepend` |
+| `summary_fallback_provider_id` | Retry with this provider when the primary summarizer fails or returns empty text. | Empty |
+| `summary_speaker_mapping_prompt` | Constrain `user`, `assistant`, and first-person ownership with session and speaker variables. | Built-in mapping |
 | `score_threshold` | Filter out memories below this similarity score. | `0.0` |
 
 If memories become too noisy, lower `top_k`, increase `score_threshold`, or reduce `contexts_memory_len`.
+
+`memory_injection_position` controls placement for both `user_prompt` and `system_prompt`. `insert_system_prompt` creates a separate system message and may reduce prompt-cache hits on some models; prefer the first two modes when cache stability matters.
 
 ## Filters
 

--- a/docs/en/guide/database.md
+++ b/docs/en/guide/database.md
@@ -35,7 +35,7 @@ If `persist_directory` is empty, Mnemosyne uses the default plugin data path. Se
 Milvus is suitable for existing Milvus deployments or larger datasets. Install the optional dependency first:
 
 ```bash
-uv pip install 'pymilvus[milvus_lite]>=2.5.4,<3.0.0'
+uv pip install 'pymilvus[milvus_lite]>=2.6.0,<3.0.0'
 ```
 
 Milvus Lite example:

--- a/docs/en/reference/troubleshooting.md
+++ b/docs/en/reference/troubleshooting.md
@@ -39,6 +39,14 @@ nc -vz localhost 19530
 
 For Milvus Lite, make sure `milvus_lite_path` points to a writable path.
 
+If the log contains `No module named 'pkg_resources'`, an outdated Milvus Lite build is relying on legacy setuptools behavior. Do not downgrade AstrBot's setuptools; upgrade the optional dependency instead:
+
+```bash
+uv pip install --upgrade 'pymilvus[milvus_lite]>=2.6.0,<3.0.0'
+```
+
+New Milvus collections use a `session_id` field length of 500. For existing standard Milvus collections, Mnemosyne attempts to expand the old 72-character field online at startup; if the server cannot alter it, upgrade PyMilvus and Milvus and reload the plugin. Milvus Lite does not currently support online field alteration, so use a new collection name or export the old collection and migrate it into a new one. Mnemosyne never drops or rebuilds existing collections automatically.
+
 ## Memories Disappear After Switching Databases
 
 Different vector backends do not share data automatically. After switching, initialize the new backend and rebuild memories over time, or export records from the old backend and import them into the new one.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -35,11 +35,15 @@ Embedding Provider 的向量维度决定集合结构。更换 Embedding 模型�
 | `num_pairs` | 触发自动总结的对话轮数。 | `5` |
 | `top_k` | 检索时返回的记忆数量。 | `3` |
 | `contexts_memory_len` | 注入上下文的长期记忆数量。 | `3` |
-| `memory_injection_method` | 记忆注入方式，可放入用户提示或系统提示。 | `user_prompt` |
+| `memory_injection_method` | `user_prompt` 注入用户提示；`system_prompt` 注入 LLM 系统提示；`insert_system_prompt` 新增独立系统消息。 | `user_prompt` |
 | `memory_injection_position` | 注入位置，可选前置或后置。 | `prepend` |
+| `summary_fallback_provider_id` | 主总结模型失败或返回空内容时重试的备用模型。 | 空 |
+| `summary_speaker_mapping_prompt` | 约束 `user`、`assistant` 和第一人称归属，支持会话与说话人变量。 | 内置通用映射 |
 | `score_threshold` | 相似度阈值，低于阈值的记忆会被过滤。 | `0.0` |
 
 如果记忆过多干扰回复，可以降低 `top_k`、提高 `score_threshold` 或减少 `contexts_memory_len`。
+
+`memory_injection_position` 同时控制 `user_prompt` 和 `system_prompt` 的前后位置。`insert_system_prompt` 会创建独立系统消息；部分模型会因此重新计算提示词缓存，缓存成本敏感时优先使用前两种方式。
 
 ## 过滤能力
 

--- a/docs/guide/database.md
+++ b/docs/guide/database.md
@@ -35,7 +35,7 @@ Chroma 是默认后端。最小配置如下：
 Milvus 适合已有 Milvus 服务或数据规模较大的部署。启用前需要安装可选依赖：
 
 ```bash
-uv pip install 'pymilvus[milvus_lite]>=2.5.4,<3.0.0'
+uv pip install 'pymilvus[milvus_lite]>=2.6.0,<3.0.0'
 ```
 
 本地 Milvus Lite 示例：

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -39,6 +39,14 @@ nc -vz localhost 19530
 
 如果使用 Milvus Lite，确认 `milvus_lite_path` 指向可写路径。
 
+如果日志包含 `No module named 'pkg_resources'`，说明安装了依赖旧 setuptools 行为的 Milvus Lite。不要降级 AstrBot 的 setuptools；请升级可选依赖：
+
+```bash
+uv pip install --upgrade 'pymilvus[milvus_lite]>=2.6.0,<3.0.0'
+```
+
+新建 Milvus 集合的 `session_id` 字段长度为 500。对于旧的标准 Milvus 集合，插件会在启动时尝试从 72 在线扩容到 500；若服务器不支持，请升级 PyMilvus 与 Milvus 后重载插件。Milvus Lite 目前不支持在线修改字段，需改用新的集合名，或先导出旧集合再迁移到新集合。插件不会自动删除或重建已有集合。
+
 ## 切换数据库后旧记忆消失
 
 不同数据库后端之间不会自动共享数据。切换数据库后，需要重新初始化并重新积累记忆，或自行编写迁移脚本导出旧记录再写入新后端。

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     "Mnemosyne",
     "lxfight",
     "一个AstrBot插件，实现基于RAG技术的长期记忆功能。",
-    "2.1.6",
+    "2.1.7",
     "https://github.com/lxfight/astrbot_plugin_mnemosyne",
 )
 class Mnemosyne(Star):

--- a/memory_manager/vector_db/milvus_manager.py
+++ b/memory_manager/vector_db/milvus_manager.py
@@ -568,6 +568,66 @@ class MilvusManager:
             logger.error(f"创建集合 '{collection_name}' 时发生意外错误: {e}")
             return None
 
+    def ensure_varchar_field_max_length(
+        self,
+        collection_name: str,
+        field_name: str,
+        minimum_length: int,
+    ) -> bool:
+        """Increase a VARCHAR field limit in place without rebuilding user data."""
+        try:
+            collection = self.get_collection(collection_name)
+            if not collection:
+                return False
+
+            field = next(
+                (item for item in collection.schema.fields if item.name == field_name),
+                None,
+            )
+            if field is None or field.dtype != DataType.VARCHAR:
+                logger.error(
+                    f"集合 '{collection_name}' 缺少 VARCHAR 字段 '{field_name}'。"
+                )
+                return False
+
+            current_length = field.params.get("max_length")
+            if isinstance(current_length, int) and current_length >= minimum_length:
+                return True
+
+            if self._is_lite:
+                logger.warning(
+                    "Milvus Lite 不支持在线扩容 VARCHAR 字段。请改用新的集合名，"
+                    "或将旧集合导出后迁移到新集合。"
+                )
+                return False
+
+            handler = connections._fetch_handler(self.alias)
+            alter_field = getattr(handler, "alter_collection_field_properties", None)
+            if not callable(alter_field):
+                logger.error(
+                    "当前 PyMilvus 不支持在线扩容 VARCHAR 字段，请升级到 2.6.0 或更高版本。"
+                )
+                return False
+
+            context = connections._generate_call_context(self.alias)
+            alter_field(
+                collection_name,
+                field_name=field_name,
+                field_params={"max_length": minimum_length},
+                context=context,
+            )
+            logger.info(
+                f"已将集合 '{collection_name}' 字段 '{field_name}' 的 max_length "
+                f"从 {current_length} 扩容到 {minimum_length}。"
+            )
+            return True
+        except Exception as e:
+            logger.error(
+                f"扩容集合 '{collection_name}' 字段 '{field_name}' 失败: {e}",
+                exc_info=True,
+            )
+            return False
+
     def drop_collection(
         self, collection_name: str, timeout: float | None = None
     ) -> bool:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_mnemosyne
 desc: 一个基于Milvus数据库的长期记忆存储与查询插件
 help: 输入 /memory 查看指令帮助
-version: v2.1.6
+version: v2.1.7
 author: lxfight
 repo: https://github.com/lxfight/astrbot_plugin_mnemosyne

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # 核心依赖
 chromadb>=0.4.0,<1.0.0
-psutil>=5.9.0,<7.0.0
+psutil>=5.9.0
 
 # 可选向量数据库（按需安装）
-# pymilvus[milvus_lite]>=2.5.4,<3.0.0 # 启用 Milvus / Milvus Lite 支持
+# pymilvus[milvus_lite]>=2.6.0,<3.0.0 # 启用 Milvus / Milvus Lite 支持
 # qdrant-client>=1.7.0,<2.0.0   # 取消注释以启用 Qdrant 支持
 # weaviate-client>=3.25.0,<4.0.0 # 取消注释以启用 Weaviate 支持

--- a/tests/test_summary_provider.py
+++ b/tests/test_summary_provider.py
@@ -1,0 +1,169 @@
+from types import SimpleNamespace
+
+import pytest
+from core.memory_operations import _get_summary_llm_response
+
+
+class _Provider:
+    def __init__(self, response=None, error: Exception | None = None):
+        self.response = response
+        self.error = error
+        self.calls = []
+
+    async def text_chat(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error:
+            raise self.error
+        return self.response
+
+
+class _Context:
+    def __init__(self, fallback=None):
+        self.fallback = fallback
+        self.requested_provider_ids = []
+
+    def get_using_provider(self, **_kwargs):
+        return None
+
+    def get_provider_by_id(self, provider_id):
+        self.requested_provider_ids.append(provider_id)
+        return self.fallback
+
+
+@pytest.mark.asyncio
+async def test_summary_retries_fallback_provider_after_empty_primary_response():
+    primary = _Provider({"completion_text": "  "})
+    fallback = _Provider({"completion_text": "fallback summary"})
+    context = _Context(fallback)
+    plugin = SimpleNamespace(
+        provider=primary,
+        context=context,
+        config={
+            "summary_fallback_provider_id": "fallback-provider",
+            "use_summary_time_anchor": False,
+            "summary_speaker_mapping_prompt": "",
+        },
+    )
+
+    response = await _get_summary_llm_response(
+        plugin,
+        "conversation",
+        session_id="session-1",
+    )
+
+    assert response == {"completion_text": "fallback summary"}
+    assert len(primary.calls) == 1
+    assert len(fallback.calls) == 1
+    assert context.requested_provider_ids == ["fallback-provider"]
+
+
+@pytest.mark.asyncio
+async def test_summary_retries_fallback_provider_after_primary_error():
+    primary = _Provider(error=RuntimeError("primary unavailable"))
+    fallback = _Provider({"completion_text": "fallback summary"})
+    plugin = SimpleNamespace(
+        provider=primary,
+        context=_Context(fallback),
+        config={
+            "summary_fallback_provider_id": "fallback-provider",
+            "use_summary_time_anchor": False,
+            "summary_speaker_mapping_prompt": "",
+        },
+    )
+
+    response = await _get_summary_llm_response(
+        plugin,
+        "conversation",
+        session_id="session-1",
+    )
+
+    assert response == {"completion_text": "fallback summary"}
+    assert len(primary.calls) == 1
+    assert len(fallback.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_summary_does_not_call_fallback_after_successful_primary_response():
+    primary = _Provider({"completion_text": "primary summary"})
+    fallback = _Provider({"completion_text": "fallback summary"})
+    plugin = SimpleNamespace(
+        provider=primary,
+        context=_Context(fallback),
+        config={
+            "summary_fallback_provider_id": "fallback-provider",
+            "use_summary_time_anchor": False,
+            "summary_speaker_mapping_prompt": "",
+        },
+    )
+
+    response = await _get_summary_llm_response(
+        plugin,
+        "conversation",
+        session_id="session-1",
+    )
+
+    assert response == {"completion_text": "primary summary"}
+    assert len(primary.calls) == 1
+    assert fallback.calls == []
+
+
+@pytest.mark.asyncio
+async def test_summary_does_not_retry_same_provider_instance():
+    provider = _Provider({"completion_text": "  "})
+    plugin = SimpleNamespace(
+        provider=provider,
+        context=_Context(provider),
+        config={
+            "summary_fallback_provider_id": "same-provider",
+            "use_summary_time_anchor": False,
+            "summary_speaker_mapping_prompt": "",
+        },
+    )
+
+    response = await _get_summary_llm_response(
+        plugin,
+        "conversation",
+        session_id="session-1",
+    )
+
+    assert response is None
+    assert len(provider.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_summary_speaker_mapping_renders_conversation_identity():
+    primary = _Provider({"completion_text": "summary"})
+    plugin = SimpleNamespace(
+        provider=primary,
+        context=_Context(),
+        config={
+            "use_summary_time_anchor": False,
+            "summary_speaker_mapping_prompt": (
+                "persona={persona_id}; session={session_id}; "
+                "sender={sender_name}/{sender_id}"
+            ),
+        },
+    )
+    history = [
+        {
+            "role": "user",
+            "content": "[Alice(user-42)]: hello",
+            "metadata": {"speaker_id": "user-42"},
+        }
+    ]
+
+    await _get_summary_llm_response(
+        plugin,
+        "conversation",
+        persona_id="persona-7",
+        session_id="session-1",
+        context_history=history,
+    )
+
+    contexts = primary.calls[0]["contexts"]
+    assert contexts[-1] == {
+        "role": "system",
+        "content": (
+            "persona=persona-7; session=session-1; sender=Alice/user-42"
+        ),
+    }

--- a/tests/test_vector_db_factory.py
+++ b/tests/test_vector_db_factory.py
@@ -3,9 +3,10 @@
 测试多数据库类型支持和工厂模式
 """
 
-import pytest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
-from pathlib import Path
+
+import pytest
 
 
 class TestVectorDatabaseFactory:
@@ -190,6 +191,98 @@ class TestMilvusDbNameFix:
         # 验证 token 在连接信息中
         assert manager._token == "test_token_123"
         assert manager._connection_info.get("token") == "test_token_123"
+
+
+class TestMilvusSessionIdSchemaMigration:
+    def test_existing_session_id_field_is_expanded_in_place(self):
+        pytest.importorskip("pymilvus")
+        from memory_manager.vector_db.milvus_manager import MilvusManager
+        from pymilvus import DataType
+
+        manager = MilvusManager(
+            host="localhost",
+            port=19530,
+            plugin_data_dir="./test_data",
+        )
+        manager._is_lite = False
+        old_field = SimpleNamespace(
+            name="session_id",
+            dtype=DataType.VARCHAR,
+            params={"max_length": 72},
+        )
+        collection = MagicMock()
+        collection.schema.fields = [old_field]
+        manager.get_collection = MagicMock(return_value=collection)
+
+        handler = MagicMock()
+        with (
+            patch(
+                "memory_manager.vector_db.milvus_manager.connections._fetch_handler",
+                return_value=handler,
+            ),
+            patch(
+                "memory_manager.vector_db.milvus_manager.connections._generate_call_context",
+                return_value="call-context",
+            ),
+        ):
+            assert manager.ensure_varchar_field_max_length(
+                "memory",
+                "session_id",
+                500,
+            )
+
+        handler.alter_collection_field_properties.assert_called_once_with(
+            "memory",
+            field_name="session_id",
+            field_params={"max_length": 500},
+            context="call-context",
+        )
+
+    def test_old_milvus_lite_schema_is_not_rebuilt_automatically(self):
+        pytest.importorskip("pymilvus")
+        from memory_manager.vector_db.milvus_manager import MilvusManager
+        from pymilvus import DataType
+
+        manager = MilvusManager(
+            plugin_data_dir="./test_data",
+        )
+        manager._is_lite = True
+        old_field = SimpleNamespace(
+            name="session_id",
+            dtype=DataType.VARCHAR,
+            params={"max_length": 72},
+        )
+        collection = MagicMock()
+        collection.schema.fields = [old_field]
+        manager.get_collection = MagicMock(return_value=collection)
+
+        with patch(
+            "memory_manager.vector_db.milvus_manager.connections._fetch_handler"
+        ) as fetch_handler:
+            assert not manager.ensure_varchar_field_max_length(
+                "memory",
+                "session_id",
+                500,
+            )
+
+        fetch_handler.assert_not_called()
+
+    def test_new_collection_schema_accepts_long_session_ids(self):
+        from astrbot_plugin_mnemosyne.core import initialization
+        from astrbot_plugin_mnemosyne.core.constants import SESSION_ID_MAX_LENGTH
+
+        plugin = SimpleNamespace(
+            config={"embedding_dim": 3},
+            embedding_provider=None,
+        )
+        initialization.initialize_config_and_schema(plugin)
+
+        session_field = next(
+            field
+            for field in plugin.collection_schema.fields
+            if field.name == "session_id"
+        )
+        assert session_field.params["max_length"] == SESSION_ID_MAX_LENGTH == 500
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- allow AstrBot core psutil 7.x without imposing a future upper-bound conflict
- raise new Milvus session IDs to 500 characters and migrate standard Milvus schemas in place when supported
- add fallback summary providers and configurable speaker/persona mapping
- document Milvus Lite dependency and schema migration paths plus memory injection behavior
- synchronize plugin metadata and registration versions to v2.1.7

## Migration note

Standard Milvus collections with the old 72-character session_id field are expanded online when the server supports field alteration. Milvus Lite does not support this operation; use a new collection name or export and migrate the old collection. Existing collections are never dropped or rebuilt automatically.

## Verification

- `57 passed, 1 skipped`
- focused provider and vector database tests: `17 passed`
- JSON duplicate-key validation, compileall, and diff checks passed
- PyMilvus 2.6.15 field-alter API signature verified
- Milvus Lite integration verified that the new schema accepts a session ID longer than 72 characters

## Release behavior

Merging this PR changes `metadata.yaml` on `main` and will immediately trigger the repository auto-release workflow for v2.1.7.

Closes #119
Closes #121
Closes #124
Closes #133
Closes #136
Closes #139

## Summary by Sourcery

Add configurable summary provider fallback and speaker identity mapping while expanding Milvus session ID capacity and updating docs and metadata for the v2.1.7 release.

New Features:
- Introduce configurable fallback LLM provider for memory summarization when the primary provider fails or returns empty output.
- Add a customizable summary speaker mapping prompt that ties user, assistant, and first-person references to session and speaker metadata.
- Increase default Milvus session_id field length for new collections to a shared constant limit of 500 characters.

Bug Fixes:
- Ensure Milvus-backed collections attempt in-place expansion of outdated session_id VARCHAR length on startup without rebuilding data, with graceful handling when unsupported.
- Relax psutil version constraints to allow 7.x without imposing an upper-bound conflict in AstrBot deployments.

Enhancements:
- Refine summary request handling to validate responses, add context-aware speaker mapping, and log provider behavior more robustly.
- Improve Milvus Lite behavior by avoiding automatic schema rebuilds for legacy collections and warning when session_id expansion cannot be applied.
- Clarify memory injection modes and their impact on prompt-cache behavior in configuration guides.

Build:
- Update dependency constraints to recommend newer pymilvus[milvus_lite] versions compatible with online field alteration and to drop the psutil upper bound.

Documentation:
- Document Milvus Lite and PyMilvus version requirements, session_id schema migration paths, and the non-destructive nature of collection changes in troubleshooting guides.
- Update configuration and database documentation to describe new summary fallback and speaker mapping options and expanded memory injection behavior.
- Bump README version badge and release metadata to v2.1.7.

Tests:
- Add tests covering Milvus session_id schema expansion, Milvus Lite limitations, and new collection schema constraints.
- Add tests for summary provider fallback behavior, response validation, and speaker mapping prompt rendering.