### PR TITLE
fix: preserve hashes in release changelog

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -75,7 +75,7 @@ jobs:
             echo "" >> changelog.md
             
             # 获取提交信息并分类
-            git log "$OLD_VERSION..HEAD" --pretty=format:"%s|||%h|||%an" --no-merges | while IFS='|||' read -r subject hash author; do
+            git log "$OLD_VERSION..HEAD" --pretty=format:"%s%x09%h%x09%an" --no-merges | while IFS=$'\t' read -r subject hash author; do
               # 根据提交信息的前缀进行分类
               if echo "$subject" | grep -qiE "^(feat|feature):"; then
                 echo "- ✨ **Feature**: ${subject#*: } (${hash})" >> changelog.md


### PR DESCRIPTION
## Summary

The release workflow used `IFS="|||"`, but shell `IFS` treats this as a set of delimiter characters rather than a multi-character delimiter. As a result, generated release notes contained empty commit hashes such as `()`.

This switches the structured `git log` output to tab-separated fields and reads it with a tab `IFS`.

## Verification

Local reproduction against `v2.1.6..HEAD` now parses:

```text
fix: resolve open issues for v2.1.7 | cdca9d2 | lxfight
```

This PR does not change `metadata.yaml` and will not trigger another release.

## Summary by Sourcery

CI:
- Update auto-release workflow to parse structured git log output using tab-separated fields instead of a custom multi-character IFS delimiter.