### PR TITLE
feat(admin): add editable memory workspace

### DIFF
--- a/admin_panel/services/memory_service.py
+++ b/admin_panel/services/memory_service.py
@@ -442,11 +442,6 @@ class MemoryService:
         output_fields = ["session_id", "content", "create_time", "personality_id"]
         if backend == "milvus":
             output_fields.append("memory_id")
-            try:
-                numeric_id = int(memory_id)
-                filters = f"memory_id == {numeric_id}"
-            except ValueError:
-                filters = f'memory_id == "{memory_id}"'
         try:
             original = vector_db.get_by_id(
                 collection_name=collection_name,
@@ -501,6 +496,12 @@ class MemoryService:
         original_embedding = await provider.get_embedding(original_content)
         if not original_embedding:
             raise RuntimeError("无法生成回滚所需的原记忆 embedding")
+
+        try:
+            numeric_id = int(memory_id)
+            filters = f"memory_id == {numeric_id}"
+        except ValueError:
+            filters = f'memory_id == "{memory_id}"'
 
         delete_result = vector_db.delete(collection_name, filters)
         vector_db.flush([collection_name])

--- a/admin_panel/services/memory_service.py
+++ b/admin_panel/services/memory_service.py
@@ -418,6 +418,150 @@ class MemoryService:
             self.logger.error(f"删除记忆失败: {e}", exc_info=True)
             return False
 
+    async def update_memory(self, memory_id: str, content: str) -> dict[str, Any]:
+        """更新记忆内容并重新生成 embedding。"""
+        normalized_content = str(content or "").strip()
+        if not normalized_content:
+            raise ValueError("记忆内容不能为空")
+        if len(normalized_content) > 4096:
+            raise ValueError("记忆内容不能超过 4096 个字符")
+
+        vector_db = self._get_vector_db()
+        if not vector_db or not vector_db.is_connected():
+            raise RuntimeError("向量数据库未连接")
+
+        collection_name = self.plugin.collection_name
+        if not vector_db.has_collection(collection_name):
+            raise RuntimeError("记忆集合不存在")
+
+        provider = getattr(self.plugin, "embedding_provider", None)
+        if not provider:
+            raise RuntimeError("Embedding Provider 未初始化")
+
+        backend = self._vector_db_type()
+        output_fields = ["session_id", "content", "create_time", "personality_id"]
+        if backend == "milvus":
+            output_fields.append("memory_id")
+            try:
+                numeric_id = int(memory_id)
+                filters = f"memory_id == {numeric_id}"
+            except ValueError:
+                filters = f'memory_id == "{memory_id}"'
+            candidates = vector_db.query(
+                collection_name=collection_name,
+                filters=filters,
+                output_fields=output_fields,
+                limit=1,
+            )
+        else:
+            candidates = vector_db.query(
+                collection_name=collection_name,
+                filters=self._all_records_expr(),
+                output_fields=output_fields,
+                limit=10000,
+            )
+            candidates = [
+                item for item in candidates if self._record_id(item) == memory_id
+            ][:1]
+
+        if not candidates:
+            raise ValueError("记忆记录不存在")
+
+        original = candidates[0]
+        original_content = str(original.get("content", ""))
+        create_time = original.get("create_time")
+        if isinstance(create_time, datetime):
+            create_time = create_time.timestamp()
+        elif isinstance(create_time, str):
+            try:
+                create_time = datetime.fromisoformat(create_time).timestamp()
+            except ValueError:
+                create_time = datetime.now().timestamp()
+        elif not isinstance(create_time, (int, float)):
+            create_time = datetime.now().timestamp()
+
+        new_embedding = await provider.get_embedding(normalized_content)
+        if not new_embedding:
+            raise RuntimeError("无法为更新后的记忆生成 embedding")
+
+        updated_payload = {
+            "content": normalized_content,
+            "embedding": new_embedding,
+            "personality_id": original.get("personality_id", ""),
+            "session_id": original.get("session_id", ""),
+            "create_time": int(create_time),
+        }
+
+        if backend != "milvus":
+            result = vector_db.update(collection_name, memory_id, updated_payload)
+            vector_db.flush([collection_name])
+            if result.insert_count != 1:
+                raise RuntimeError("向量数据库未确认更新操作")
+            updated_id = str(result.primary_keys[0]) if result.primary_keys else memory_id
+            return self._updated_memory_response(
+                memory_id, updated_id, updated_payload
+            )
+
+        # Milvus 集合使用 AutoID，无法原地保留主键。删除前同时生成旧向量，
+        # 这样新记录插入失败时仍可恢复原内容。
+        original_embedding = await provider.get_embedding(original_content)
+        if not original_embedding:
+            raise RuntimeError("无法生成回滚所需的原记忆 embedding")
+
+        delete_result = vector_db.delete(collection_name, filters)
+        vector_db.flush([collection_name])
+        if (
+            delete_result.delete_count is not None
+            and delete_result.delete_count < 1
+        ):
+            raise RuntimeError("原记忆删除失败，更新已取消")
+
+        try:
+            insert_result = vector_db.insert(collection_name, [updated_payload])
+            vector_db.flush([collection_name])
+            if insert_result.insert_count != 1:
+                raise RuntimeError("更新后的记忆插入失败")
+        except Exception as update_error:
+            rollback_payload = {
+                **updated_payload,
+                "content": original_content,
+                "embedding": original_embedding,
+            }
+            try:
+                rollback_result = vector_db.insert(collection_name, [rollback_payload])
+                vector_db.flush([collection_name])
+                if rollback_result.insert_count != 1:
+                    raise RuntimeError("回滚插入未成功")
+            except Exception as rollback_error:
+                raise RuntimeError(
+                    "记忆更新失败且原记录无法恢复，请立即检查向量数据库"
+                ) from rollback_error
+            raise RuntimeError("记忆更新失败，原内容已恢复") from update_error
+
+        updated_id = (
+            str(insert_result.primary_keys[0])
+            if insert_result.primary_keys
+            else memory_id
+        )
+        return self._updated_memory_response(memory_id, updated_id, updated_payload)
+
+    @staticmethod
+    def _updated_memory_response(
+        previous_id: str,
+        updated_id: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "memory_id": updated_id,
+            "previous_memory_id": previous_id,
+            "id_changed": updated_id != previous_id,
+            "content": payload["content"],
+            "session_id": payload.get("session_id", ""),
+            "persona_id": payload.get("personality_id", ""),
+            "create_time": datetime.fromtimestamp(payload["create_time"]).isoformat(),
+            "embedding_regenerated": True,
+        }
+
     async def delete_session_memories(self, session_id: str) -> int:
         """
         删除指定会话的所有记忆

--- a/admin_panel/services/memory_service.py
+++ b/admin_panel/services/memory_service.py
@@ -447,27 +447,18 @@ class MemoryService:
                 filters = f"memory_id == {numeric_id}"
             except ValueError:
                 filters = f'memory_id == "{memory_id}"'
-            candidates = vector_db.query(
+        try:
+            original = vector_db.get_by_id(
                 collection_name=collection_name,
-                filters=filters,
+                record_id=memory_id,
                 output_fields=output_fields,
-                limit=1,
             )
-        else:
-            candidates = vector_db.query(
-                collection_name=collection_name,
-                filters=self._all_records_expr(),
-                output_fields=output_fields,
-                limit=10000,
-            )
-            candidates = [
-                item for item in candidates if self._record_id(item) == memory_id
-            ][:1]
+        except NotImplementedError as e:
+            raise RuntimeError("当前向量数据库不支持按 ID 更新记忆") from e
 
-        if not candidates:
+        if not original:
             raise ValueError("记忆记录不存在")
 
-        original = candidates[0]
         original_content = str(original.get("content", ""))
         create_time = original.get("create_time")
         if isinstance(create_time, datetime):
@@ -493,7 +484,10 @@ class MemoryService:
         }
 
         if backend != "milvus":
-            result = vector_db.update(collection_name, memory_id, updated_payload)
+            try:
+                result = vector_db.update(collection_name, memory_id, updated_payload)
+            except NotImplementedError as e:
+                raise RuntimeError("当前向量数据库不支持原地更新记忆") from e
             vector_db.flush([collection_name])
             if result.insert_count != 1:
                 raise RuntimeError("向量数据库未确认更新操作")

--- a/memory_manager/vector_db/chroma_adapter.py
+++ b/memory_manager/vector_db/chroma_adapter.py
@@ -271,6 +271,31 @@ class ChromaVectorDB(VectorDatabase):
             logger.error(f"查询集合 '{collection_name}' 失败: {e}", exc_info=True)
             raise
 
+    def update(
+        self,
+        collection_name: str,
+        record_id: str,
+        data: dict[str, Any],
+    ) -> VectorInsertResult:
+        """使用 Chroma 原生 update 保留文档 ID。"""
+        self._ensure_connected()
+        embedding = data.get("embedding")
+        if not embedding:
+            raise ValueError("更新 Chroma 记录时 embedding 不能为空")
+
+        collection = self._client.get_collection(name=collection_name)
+        collection.update(
+            ids=[record_id],
+            embeddings=[embedding],
+            documents=[data.get("content", "")],
+            metadatas=[{
+                "personality_id": data.get("personality_id", ""),
+                "session_id": data.get("session_id", ""),
+                "create_time": data.get("create_time", int(time.time())),
+            }],
+        )
+        return VectorInsertResult(insert_count=1, primary_keys=[record_id])
+
     def search(
         self,
         collection_name: str,

--- a/memory_manager/vector_db/chroma_adapter.py
+++ b/memory_manager/vector_db/chroma_adapter.py
@@ -296,6 +296,29 @@ class ChromaVectorDB(VectorDatabase):
         )
         return VectorInsertResult(insert_count=1, primary_keys=[record_id])
 
+    def get_by_id(
+        self,
+        collection_name: str,
+        record_id: str,
+        output_fields: list[str] | None = None,
+    ) -> dict[str, Any] | None:
+        """通过 Chroma 文档 ID 直接读取记录。"""
+        self._ensure_connected()
+        collection = self._client.get_collection(name=collection_name)
+        result = collection.get(
+            ids=[record_id],
+            include=["metadatas", "documents"],
+        )
+        if not result.get("ids"):
+            return None
+        record = {
+            "id": result["ids"][0],
+            "content": (result.get("documents") or [""])[0],
+        }
+        metadata = (result.get("metadatas") or [{}])[0] or {}
+        record.update(metadata)
+        return record
+
     def search(
         self,
         collection_name: str,

--- a/memory_manager/vector_db/milvus_adapter.py
+++ b/memory_manager/vector_db/milvus_adapter.py
@@ -202,6 +202,26 @@ class MilvusVectorDB(VectorDatabase):
             logger.error(f"查询集合 '{collection_name}' 失败: {e}")
             raise
 
+    def get_by_id(
+        self,
+        collection_name: str,
+        record_id: str,
+        output_fields: list[str] | None = None,
+    ) -> dict[str, Any] | None:
+        """通过 Milvus 主键直接读取记录。"""
+        try:
+            normalized_id = int(record_id)
+            filters = f"memory_id == {normalized_id}"
+        except ValueError:
+            filters = f'memory_id == "{record_id}"'
+        records = self.query(
+            collection_name=collection_name,
+            filters=filters,
+            output_fields=output_fields,
+            limit=1,
+        )
+        return records[0] if records else None
+
     def search(
         self,
         collection_name: str,

--- a/memory_manager/vector_db/qdrant_adapter.py
+++ b/memory_manager/vector_db/qdrant_adapter.py
@@ -256,6 +256,24 @@ class QdrantVectorDB(VectorDatabase):
         self._client.upsert(collection_name=collection_name, points=[point])
         return VectorInsertResult(insert_count=1, primary_keys=[record_id])
 
+    def get_by_id(
+        self,
+        collection_name: str,
+        record_id: str,
+        output_fields: list[str] | None = None,
+    ) -> dict[str, Any] | None:
+        """通过 Qdrant point ID 直接读取记录。"""
+        self._ensure_connected()
+        points = self._client.retrieve(
+            collection_name=collection_name,
+            ids=[record_id],
+            with_payload=True,
+            with_vectors=False,
+        )
+        if not points:
+            return None
+        return {"id": points[0].id, **(points[0].payload or {})}
+
     def search(
         self,
         collection_name: str,

--- a/memory_manager/vector_db/qdrant_adapter.py
+++ b/memory_manager/vector_db/qdrant_adapter.py
@@ -229,6 +229,33 @@ class QdrantVectorDB(VectorDatabase):
             logger.error(f"查询集合 '{collection_name}' 失败: {e}", exc_info=True)
             raise
 
+    def update(
+        self,
+        collection_name: str,
+        record_id: str,
+        data: dict[str, Any],
+    ) -> VectorInsertResult:
+        """使用 Qdrant upsert 原子替换并保留 point ID。"""
+        self._ensure_connected()
+        embedding = data.get("embedding")
+        if not embedding:
+            raise ValueError("更新 Qdrant 记录时 embedding 不能为空")
+
+        from qdrant_client.models import PointStruct
+
+        point = PointStruct(
+            id=record_id,
+            vector=embedding,
+            payload={
+                "content": data.get("content", ""),
+                "personality_id": data.get("personality_id", ""),
+                "session_id": data.get("session_id", ""),
+                "create_time": data.get("create_time", int(time.time())),
+            },
+        )
+        self._client.upsert(collection_name=collection_name, points=[point])
+        return VectorInsertResult(insert_count=1, primary_keys=[record_id])
+
     def search(
         self,
         collection_name: str,

--- a/memory_manager/vector_db/weaviate_adapter.py
+++ b/memory_manager/vector_db/weaviate_adapter.py
@@ -275,6 +275,26 @@ class WeaviateVectorDB(VectorDatabase):
         )
         return VectorInsertResult(insert_count=1, primary_keys=[record_id])
 
+    def get_by_id(
+        self,
+        collection_name: str,
+        record_id: str,
+        output_fields: list[str] | None = None,
+    ) -> dict[str, Any] | None:
+        """通过 Weaviate UUID 直接读取记录。"""
+        self._ensure_connected()
+        result = self._client.data_object.get_by_id(
+            uuid=record_id,
+            class_name=collection_name.capitalize(),
+            with_vector=False,
+        )
+        if not result:
+            return None
+        return {
+            "id": result.get("id", record_id),
+            **(result.get("properties") or {}),
+        }
+
     def search(
         self,
         collection_name: str,

--- a/memory_manager/vector_db/weaviate_adapter.py
+++ b/memory_manager/vector_db/weaviate_adapter.py
@@ -249,6 +249,32 @@ class WeaviateVectorDB(VectorDatabase):
             logger.error(f"查询集合 '{collection_name}' 失败: {e}", exc_info=True)
             raise
 
+    def update(
+        self,
+        collection_name: str,
+        record_id: str,
+        data: dict[str, Any],
+    ) -> VectorInsertResult:
+        """使用 Weaviate 对象更新接口保留 UUID。"""
+        self._ensure_connected()
+        embedding = data.get("embedding")
+        if not embedding:
+            raise ValueError("更新 Weaviate 记录时 embedding 不能为空")
+
+        class_name = collection_name.capitalize()
+        self._client.data_object.update(
+            uuid=record_id,
+            class_name=class_name,
+            data_object={
+                "content": data.get("content", ""),
+                "personality_id": data.get("personality_id", ""),
+                "session_id": data.get("session_id", ""),
+                "create_time": data.get("create_time", int(time.time())),
+            },
+            vector=embedding,
+        )
+        return VectorInsertResult(insert_count=1, primary_keys=[record_id])
+
     def search(
         self,
         collection_name: str,

--- a/memory_manager/vector_db_base.py
+++ b/memory_manager/vector_db_base.py
@@ -67,6 +67,17 @@ class VectorDatabase(ABC):
             f"{self.__class__.__name__} does not support in-place updates"
         )
 
+    def get_by_id(
+        self,
+        collection_name: str,
+        record_id: str,
+        output_fields: list[str] | None = None,
+    ) -> dict[str, Any] | None:
+        """按数据库原生 ID 获取单条记录。"""
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support direct ID lookup"
+        )
+
     @abstractmethod
     def query(
         self,

--- a/memory_manager/vector_db_base.py
+++ b/memory_manager/vector_db_base.py
@@ -56,6 +56,17 @@ class VectorDatabase(ABC):
         """
         pass
 
+    def update(
+        self,
+        collection_name: str,
+        record_id: str,
+        data: dict[str, Any],
+    ) -> VectorInsertResult:
+        """更新单条记录；不支持原生更新的后端应显式抛出。"""
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support in-place updates"
+        )
+
     @abstractmethod
     def query(
         self,

--- a/pages/panel/app.js
+++ b/pages/panel/app.js
@@ -28,6 +28,8 @@ const AppState = {
     sessionsData: null,
     statisticsData: null,
     memoryField: null,
+    inspectedMemoryId: null,
+    inspectorOriginalContent: '',
 };
 
 // ==================== Bridge API 封装 ====================
@@ -103,6 +105,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     setupNavigation();
     setupClock();
     setupMemoryField();
+    setupMemoryInspector();
 
     refreshIcons();
 
@@ -185,6 +188,24 @@ function setupMemoryField() {
     if (canvas && window.MnemosyneMemoryField) {
         AppState.memoryField = new window.MnemosyneMemoryField(canvas);
     }
+}
+
+function setupMemoryInspector() {
+    const closeButton = document.getElementById('memory-inspector-close');
+    const cancelButton = document.getElementById('memory-inspector-cancel');
+    const saveButton = document.getElementById('memory-inspector-save');
+    const backdrop = document.getElementById('memory-inspector-backdrop');
+    const editor = document.getElementById('inspector-content');
+    closeButton?.addEventListener('click', closeMemoryInspector);
+    cancelButton?.addEventListener('click', closeMemoryInspector);
+    backdrop?.addEventListener('click', closeMemoryInspector);
+    saveButton?.addEventListener('click', saveMemoryChanges);
+    editor?.addEventListener('input', updateInspectorDraftState);
+    document.addEventListener('keydown', event => {
+        if (event.key === 'Escape' && AppState.inspectedMemoryId) {
+            closeMemoryInspector();
+        }
+    });
 }
 
 function loadPage(pageName) {
@@ -564,6 +585,14 @@ function updateBatchActions() {
     if (selectedCountEl) selectedCountEl.textContent = selectedMemoryIds.size;
 }
 
+function clearMemorySelection() {
+    selectedMemoryIds.clear();
+    document.querySelectorAll('.memory-item input[type="checkbox"]').forEach(checkbox => {
+        checkbox.checked = false;
+    });
+    updateBatchActions();
+}
+
 async function batchDeleteMemories() {
     if (selectedMemoryIds.size === 0) { showToast('请先选择要删除的记忆', 'warning'); return; }
     if (!confirm(`确定要删除选中的 ${selectedMemoryIds.size} 条记忆吗？此操作不可恢复！`)) return;
@@ -595,48 +624,103 @@ async function deleteMemory(memoryId) {
 }
 
 function viewMemoryDetail(memoryId) {
-    const memory = AppState.memoriesData?.records?.find(m => m.memory_id === memoryId);
+    const memory = allMemoriesCache.find(m => m.memory_id === memoryId)
+        || AppState.memoriesData?.records?.find(m => m.memory_id === memoryId);
     if (!memory) { showToast('记忆数据未找到', 'error'); return; }
 
-    const modal = document.createElement('div'); modal.className = 'modal';
-    const modalContent = document.createElement('div'); modalContent.className = 'modal-content';
-    const modalHeader = document.createElement('div'); modalHeader.className = 'modal-header';
-    const title = document.createElement('h3'); title.textContent = '记忆详情';
-    const closeBtn = document.createElement('button'); closeBtn.className = 'btn-close'; closeBtn.title = '关闭'; closeBtn.setAttribute('aria-label', '关闭记忆详情'); closeBtn.appendChild(createIconElement('x')); closeBtn.onclick = () => modal.remove();
-    modalHeader.appendChild(title); modalHeader.appendChild(closeBtn);
+    AppState.inspectedMemoryId = memory.memory_id;
+    AppState.inspectorOriginalContent = memory.content || '';
+    document.getElementById('inspector-memory-id').textContent = memory.memory_id || '--';
+    document.getElementById('inspector-session-id').textContent = memory.session_id || '--';
+    document.getElementById('inspector-persona-id').textContent = memory.persona_id || '--';
+    document.getElementById('inspector-create-time').textContent = formatTime(memory.create_time || memory.timestamp);
+    const editor = document.getElementById('inspector-content');
+    editor.value = AppState.inspectorOriginalContent;
+    document.getElementById('inspector-character-count').textContent = String(editor.value.length);
+    document.getElementById('inspector-save-status').textContent = '编辑内容后将重新生成向量';
+    document.getElementById('memory-inspector-save').disabled = true;
 
-    const modalBody = document.createElement('div'); modalBody.className = 'modal-body';
-    const addDetail = (label, value) => {
-        const itemDiv = document.createElement('div'); itemDiv.className = 'detail-item';
-        const labelEl = document.createElement('label'); labelEl.textContent = label + ':';
-        const valueEl = document.createElement('span'); valueEl.textContent = value;
-        itemDiv.appendChild(labelEl); itemDiv.appendChild(valueEl);
-        modalBody.appendChild(itemDiv);
-    };
+    const inspector = document.getElementById('memory-inspector');
+    const backdrop = document.getElementById('memory-inspector-backdrop');
+    inspector.classList.add('open');
+    inspector.setAttribute('aria-hidden', 'false');
+    backdrop.classList.add('open');
+    backdrop.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('inspector-open');
+    setTimeout(() => editor.focus(), 280);
+}
 
-    addDetail('记忆ID', memory.memory_id);
-    addDetail('会话ID', memory.session_id);
-    addDetail('时间', formatTime(memory.create_time || memory.timestamp));
-    addDetail('类型', getMemoryTypeText(memory.metadata?.memory_type || memory.memory_type || 'long_term'));
-    if (memory.similarity_score != null) addDetail('相似度', memory.similarity_score.toFixed(3));
+function closeMemoryInspector() {
+    const inspector = document.getElementById('memory-inspector');
+    const backdrop = document.getElementById('memory-inspector-backdrop');
+    inspector?.classList.remove('open');
+    inspector?.setAttribute('aria-hidden', 'true');
+    backdrop?.classList.remove('open');
+    backdrop?.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('inspector-open');
+    AppState.inspectedMemoryId = null;
+    AppState.inspectorOriginalContent = '';
+}
 
-    const contentItem = document.createElement('div'); contentItem.className = 'detail-item';
-    const contentLabel = document.createElement('label'); contentLabel.textContent = '内容:';
-    const contentValue = document.createElement('div');
-    contentValue.style.cssText = 'white-space: pre-wrap; margin-top: 0.5rem; padding: 1rem; background: var(--bg-secondary); border-radius: 4px;';
-    contentValue.textContent = memory.content;
-    contentItem.appendChild(contentLabel); contentItem.appendChild(contentValue);
-    modalBody.appendChild(contentItem);
+function updateInspectorDraftState() {
+    const editor = document.getElementById('inspector-content');
+    const saveButton = document.getElementById('memory-inspector-save');
+    const status = document.getElementById('inspector-save-status');
+    const content = editor.value;
+    const normalized = content.trim();
+    const changed = normalized !== AppState.inspectorOriginalContent.trim();
+    document.getElementById('inspector-character-count').textContent = String(content.length);
+    saveButton.disabled = !normalized || !changed;
+    status.textContent = !normalized
+        ? '记忆内容不能为空'
+        : changed
+            ? '保存时将重新生成向量'
+            : '当前内容没有变化';
+}
 
-    const modalFooter = document.createElement('div'); modalFooter.className = 'modal-footer';
-    const closeFooterBtn = document.createElement('button'); closeFooterBtn.className = 'btn btn-secondary'; closeFooterBtn.textContent = '关闭'; closeFooterBtn.onclick = () => modal.remove();
-    modalFooter.appendChild(closeFooterBtn);
+async function saveMemoryChanges() {
+    const memoryId = AppState.inspectedMemoryId;
+    const editor = document.getElementById('inspector-content');
+    const saveButton = document.getElementById('memory-inspector-save');
+    const status = document.getElementById('inspector-save-status');
+    const content = editor.value.trim();
+    if (!memoryId || !content || saveButton.disabled) return;
 
-    modalContent.appendChild(modalHeader); modalContent.appendChild(modalBody); modalContent.appendChild(modalFooter);
-    modal.appendChild(modalContent);
-    document.body.appendChild(modal);
-    refreshIcons();
-    modal.addEventListener('click', (e) => { if (e.target === modal) modal.remove(); });
+    saveButton.disabled = true;
+    status.textContent = '正在重建向量';
+    showLoading(true);
+    try {
+        const result = await apiPost(`memories/${memoryId}/update`, { content });
+        if (!result || result.status === 'error' || !result.record) {
+            throw new Error(result?.message || '更新接口未返回记录');
+        }
+
+        const updated = result.record;
+        const updateRecord = record => {
+            if (record.memory_id !== memoryId) return;
+            record.memory_id = updated.memory_id;
+            record.content = updated.content;
+            record.create_time = updated.create_time || record.create_time;
+            record.persona_id = updated.persona_id ?? record.persona_id;
+        };
+        allMemoriesCache.forEach(updateRecord);
+        AppState.memoriesData?.records?.forEach(updateRecord);
+
+        if (updated.id_changed && selectedMemoryIds.delete(memoryId)) {
+            selectedMemoryIds.add(updated.memory_id);
+        }
+        const groupBy = currentSearchParams.group_by || '';
+        if (groupBy) renderGroupedMemories(allMemoriesCache, groupBy);
+        else renderMemoriesList(allMemoriesCache);
+        closeMemoryInspector();
+        showToast(updated.id_changed ? '记忆已更新，数据库已分配新 ID' : '记忆与向量已更新', 'success');
+    } catch (error) {
+        status.textContent = error.message;
+        saveButton.disabled = false;
+        showToast('更新失败：' + error.message, 'error');
+    } finally {
+        showLoading(false);
+    }
 }
 
 async function exportMemories(format = 'json') {
@@ -1128,6 +1212,7 @@ window.vectorSearchMemories = vectorSearchMemories;
 window.clearFilters = clearFilters;
 window.toggleMemorySelection = toggleMemorySelection;
 window.toggleSelectAll = toggleSelectAll;
+window.clearMemorySelection = clearMemorySelection;
 window.batchDeleteMemories = batchDeleteMemories;
 window.deleteMemory = deleteMemory;
 window.viewMemoryDetail = viewMemoryDetail;

--- a/pages/panel/app.js
+++ b/pages/panel/app.js
@@ -187,6 +187,9 @@ function setupMemoryField() {
     const canvas = document.getElementById('memory-field-canvas');
     if (canvas && window.MnemosyneMemoryField) {
         AppState.memoryField = new window.MnemosyneMemoryField(canvas);
+        window.addEventListener('beforeunload', () => {
+            AppState.memoryField?.destroy();
+        }, { once: true });
     }
 }
 

--- a/pages/panel/app.js
+++ b/pages/panel/app.js
@@ -30,6 +30,7 @@ const AppState = {
     memoryField: null,
     inspectedMemoryId: null,
     inspectorOriginalContent: '',
+    inspectorTrigger: null,
 };
 
 // ==================== Bridge API 封装 ====================
@@ -205,8 +206,26 @@ function setupMemoryInspector() {
     saveButton?.addEventListener('click', saveMemoryChanges);
     editor?.addEventListener('input', updateInspectorDraftState);
     document.addEventListener('keydown', event => {
-        if (event.key === 'Escape' && AppState.inspectedMemoryId) {
+        if (!AppState.inspectedMemoryId) return;
+        if (event.key === 'Escape') {
             closeMemoryInspector();
+            return;
+        }
+        if (event.key === 'Tab') {
+            const inspector = document.getElementById('memory-inspector');
+            const focusable = Array.from(inspector?.querySelectorAll(
+                'button:not(:disabled), textarea:not(:disabled), input:not(:disabled), select:not(:disabled), [tabindex]:not([tabindex="-1"])'
+            ) || []).filter(element => element.getClientRects().length > 0);
+            if (!focusable.length) return;
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+            if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+            } else if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
         }
     });
 }
@@ -631,20 +650,35 @@ function viewMemoryDetail(memoryId) {
         || AppState.memoriesData?.records?.find(m => m.memory_id === memoryId);
     if (!memory) { showToast('记忆数据未找到', 'error'); return; }
 
-    AppState.inspectedMemoryId = memory.memory_id;
-    AppState.inspectorOriginalContent = memory.content || '';
-    document.getElementById('inspector-memory-id').textContent = memory.memory_id || '--';
-    document.getElementById('inspector-session-id').textContent = memory.session_id || '--';
-    document.getElementById('inspector-persona-id').textContent = memory.persona_id || '--';
-    document.getElementById('inspector-create-time').textContent = formatTime(memory.create_time || memory.timestamp);
-    const editor = document.getElementById('inspector-content');
-    editor.value = AppState.inspectorOriginalContent;
-    document.getElementById('inspector-character-count').textContent = String(editor.value.length);
-    document.getElementById('inspector-save-status').textContent = '编辑内容后将重新生成向量';
-    document.getElementById('memory-inspector-save').disabled = true;
-
     const inspector = document.getElementById('memory-inspector');
     const backdrop = document.getElementById('memory-inspector-backdrop');
+    const editor = document.getElementById('inspector-content');
+    const memoryIdElement = document.getElementById('inspector-memory-id');
+    const sessionIdElement = document.getElementById('inspector-session-id');
+    const personaIdElement = document.getElementById('inspector-persona-id');
+    const createTimeElement = document.getElementById('inspector-create-time');
+    const countElement = document.getElementById('inspector-character-count');
+    const statusElement = document.getElementById('inspector-save-status');
+    const saveButton = document.getElementById('memory-inspector-save');
+    if (!inspector || !backdrop || !editor || !memoryIdElement
+        || !sessionIdElement || !personaIdElement || !createTimeElement
+        || !countElement || !statusElement || !saveButton) {
+        showToast('记忆检查器未正确加载', 'error');
+        return;
+    }
+
+    AppState.inspectorTrigger = document.activeElement;
+    AppState.inspectedMemoryId = memory.memory_id;
+    AppState.inspectorOriginalContent = memory.content || '';
+    memoryIdElement.textContent = memory.memory_id || '--';
+    sessionIdElement.textContent = memory.session_id || '--';
+    personaIdElement.textContent = memory.persona_id || '--';
+    createTimeElement.textContent = formatTime(memory.create_time || memory.timestamp);
+    editor.value = AppState.inspectorOriginalContent;
+    countElement.textContent = String(editor.value.length);
+    statusElement.textContent = '编辑内容后将重新生成向量';
+    saveButton.disabled = true;
+
     inspector.classList.add('open');
     inspector.setAttribute('aria-hidden', 'false');
     backdrop.classList.add('open');
@@ -661,8 +695,11 @@ function closeMemoryInspector() {
     backdrop?.classList.remove('open');
     backdrop?.setAttribute('aria-hidden', 'true');
     document.body.classList.remove('inspector-open');
+    const trigger = AppState.inspectorTrigger;
     AppState.inspectedMemoryId = null;
     AppState.inspectorOriginalContent = '';
+    AppState.inspectorTrigger = null;
+    if (trigger instanceof HTMLElement && trigger.isConnected) trigger.focus();
 }
 
 function updateInspectorDraftState() {

--- a/pages/panel/demo-bridge.js
+++ b/pages/panel/demo-bridge.js
@@ -123,6 +123,21 @@
                 const records = memories.slice(0, Number(body.limit || 20));
                 return { records, total_count: records.length };
             }
+            const updateMatch = endpoint.match(/^memories\/([^/]+)\/update$/);
+            if (updateMatch) {
+                const memory = memories.find(item => item.memory_id === updateMatch[1]);
+                if (!memory) return { status: 'error', message: '记忆记录不存在' };
+                memory.content = String(body.content || '').trim();
+                return {
+                    updated: true,
+                    record: {
+                        ...memory,
+                        previous_memory_id: memory.memory_id,
+                        id_changed: false,
+                        embedding_regenerated: true,
+                    },
+                };
+            }
             return { success: true };
         },
         download: async () => true,

--- a/pages/panel/index.html
+++ b/pages/panel/index.html
@@ -153,7 +153,14 @@
 
                     <div class="ledger-toolbar">
                         <div class="info-bar"><span id="memories-count-info">共 0 条记忆</span><span id="memories-filter-info"></span></div>
-                        <div id="batch-actions" class="batch-actions"><span>已选择 <strong id="selected-count">0</strong> 条</span><button class="btn btn-danger btn-sm" type="button" onclick="batchDeleteMemories()"><i data-lucide="trash-2"></i><span>批量删除</span></button></div>
+                        <div class="selection-tools">
+                            <button class="btn btn-sm" type="button" onclick="toggleSelectAll()"><i data-lucide="square-check-big"></i><span>全选</span></button>
+                            <div id="batch-actions" class="batch-actions">
+                                <span>已选择 <strong id="selected-count">0</strong> 条</span>
+                                <button class="btn btn-sm" type="button" onclick="clearMemorySelection()"><i data-lucide="x"></i><span>清空</span></button>
+                                <button class="btn btn-danger btn-sm" type="button" onclick="batchDeleteMemories()"><i data-lucide="trash-2"></i><span>批量删除</span></button>
+                            </div>
+                        </div>
                     </div>
                     <div id="memories-list" class="list-container memory-ledger"><div class="loading-placeholder"><i data-lucide="loader-circle"></i><p>正在读取记忆</p></div></div>
                     <div id="memories-pagination" class="pagination"></div>
@@ -197,6 +204,35 @@
             </div>
         </main>
     </div>
+
+    <div id="memory-inspector-backdrop" class="memory-inspector-backdrop" aria-hidden="true"></div>
+    <aside id="memory-inspector" class="memory-inspector" aria-labelledby="memory-inspector-title" aria-hidden="true">
+        <header class="memory-inspector-header">
+            <div>
+                <p class="eyebrow">MEMORY / INSPECTOR</p>
+                <h2 id="memory-inspector-title">记忆检查器</h2>
+            </div>
+            <button id="memory-inspector-close" class="btn-close" type="button" title="关闭" aria-label="关闭记忆检查器"><i data-lucide="x"></i></button>
+        </header>
+        <div class="memory-inspector-body">
+            <dl class="memory-inspector-meta">
+                <div><dt>记忆 ID</dt><dd id="inspector-memory-id">--</dd></div>
+                <div><dt>会话</dt><dd id="inspector-session-id">--</dd></div>
+                <div><dt>人格</dt><dd id="inspector-persona-id">--</dd></div>
+                <div><dt>创建时间</dt><dd id="inspector-create-time">--</dd></div>
+            </dl>
+            <label class="memory-editor-label" for="inspector-content">记忆内容</label>
+            <textarea id="inspector-content" class="memory-editor" maxlength="4096" rows="12"></textarea>
+            <div class="memory-editor-status">
+                <span id="inspector-save-status">编辑内容后将重新生成向量</span>
+                <span><strong id="inspector-character-count">0</strong> / 4096</span>
+            </div>
+        </div>
+        <footer class="memory-inspector-footer">
+            <button id="memory-inspector-cancel" class="btn" type="button">取消</button>
+            <button id="memory-inspector-save" class="btn btn-primary" type="button" disabled><i data-lucide="save"></i><span>保存并重建向量</span></button>
+        </footer>
+    </aside>
 
     <div id="loading-overlay" class="loading-overlay"><div class="loading-core"><i data-lucide="loader-circle"></i></div><p>正在同步数据</p></div>
     <div id="toast-container" class="toast-container" aria-live="polite"></div>

--- a/pages/panel/memory-field.js
+++ b/pages/panel/memory-field.js
@@ -30,11 +30,13 @@
             this.time = 0;
             this.frame = null;
             this.palette = {};
+            this.abortController = new AbortController();
             this.resizeObserver = new ResizeObserver(() => this.resize());
             this.resizeObserver.observe(this.stage);
             this.intersectionObserver = new IntersectionObserver(([entry]) => {
                 this.visible = entry.isIntersecting;
                 if (this.visible) this.start();
+                else this.stop();
             }, { threshold: 0.05 });
             this.intersectionObserver.observe(this.stage);
             this.bindEvents();
@@ -43,6 +45,7 @@
         }
 
         bindEvents() {
+            const eventOptions = { signal: this.abortController.signal };
             this.canvas.addEventListener('pointermove', event => {
                 const rect = this.canvas.getBoundingClientRect();
                 this.pointer.x = event.clientX - rect.left;
@@ -54,26 +57,33 @@
                     this.pointer.draggedNode.vx = 0;
                     this.pointer.draggedNode.vy = 0;
                 }
-            });
+            }, eventOptions);
             this.canvas.addEventListener('pointerleave', () => {
                 this.pointer.active = false;
                 this.pointer.draggedNode = null;
-            });
+            }, eventOptions);
             this.canvas.addEventListener('pointerdown', event => {
                 const rect = this.canvas.getBoundingClientRect();
                 const x = event.clientX - rect.left;
                 const y = event.clientY - rect.top;
                 this.pointer.draggedNode = this.findNearestNode(x, y, 48);
                 if (this.pointer.draggedNode) this.canvas.setPointerCapture(event.pointerId);
-            });
+            }, eventOptions);
             this.canvas.addEventListener('pointerup', event => {
                 this.pointer.draggedNode = null;
                 if (this.canvas.hasPointerCapture(event.pointerId)) this.canvas.releasePointerCapture(event.pointerId);
-            });
+            }, eventOptions);
             prefersReducedMotion.addEventListener('change', () => {
                 if (prefersReducedMotion.matches) this.stop();
                 this.draw();
-            });
+            }, eventOptions);
+        }
+
+        destroy() {
+            this.stop();
+            this.abortController.abort();
+            this.resizeObserver.disconnect();
+            this.intersectionObserver.disconnect();
         }
 
         refreshPalette() {
@@ -304,7 +314,7 @@
             ctx.lineWidth = 1;
             const corner = Math.min(13, size * 0.24);
             ctx.beginPath();
-            ctx.roundRect(-size, -size * 0.72, size * 2, size * 1.44, corner);
+            this.roundedRectPath(ctx, -size, -size * 0.72, size * 2, size * 1.44, corner);
             ctx.fill();
             ctx.stroke();
             ctx.shadowColor = 'transparent';
@@ -317,6 +327,24 @@
             ctx.globalAlpha = 0.72;
             ctx.fillText(node.value, 0, 13);
             ctx.restore();
+        }
+
+        roundedRectPath(ctx, x, y, width, height, radius) {
+            if (typeof ctx.roundRect === 'function') {
+                ctx.roundRect(x, y, width, height, radius);
+                return;
+            }
+            const right = x + width;
+            const bottom = y + height;
+            ctx.moveTo(x + radius, y);
+            ctx.lineTo(right - radius, y);
+            ctx.quadraticCurveTo(right, y, right, y + radius);
+            ctx.lineTo(right, bottom - radius);
+            ctx.quadraticCurveTo(right, bottom, right - radius, bottom);
+            ctx.lineTo(x + radius, bottom);
+            ctx.quadraticCurveTo(x, bottom, x, bottom - radius);
+            ctx.lineTo(x, y + radius);
+            ctx.quadraticCurveTo(x, y, x + radius, y);
         }
     }
 

--- a/pages/panel/style.css
+++ b/pages/panel/style.css
@@ -966,6 +966,12 @@ select.input {
     font-size: 11px;
 }
 
+.selection-tools {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
 .list-container { min-height: 220px; }
 
 .memory-ledger,
@@ -1324,6 +1330,168 @@ select.input {
     backdrop-filter: blur(14px);
 }
 
+body.inspector-open {
+    overflow: hidden;
+}
+
+.memory-inspector-backdrop {
+    position: fixed;
+    z-index: 1040;
+    inset: 0;
+    background: rgba(28, 42, 43, 0.22);
+    opacity: 0;
+    pointer-events: none;
+    backdrop-filter: blur(0);
+    transition: opacity var(--ease), backdrop-filter var(--ease);
+}
+
+.memory-inspector-backdrop.open {
+    opacity: 1;
+    pointer-events: auto;
+    backdrop-filter: blur(8px);
+}
+
+.memory-inspector {
+    position: fixed;
+    z-index: 1050;
+    top: 0;
+    right: 0;
+    display: grid;
+    width: min(540px, 100vw);
+    height: 100dvh;
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    border-left: 1px solid rgba(255, 255, 255, 0.82);
+    background: color-mix(in srgb, var(--glass-strong) 94%, transparent);
+    box-shadow: -28px 0 90px rgba(39, 61, 60, 0.2);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateX(104%);
+    backdrop-filter: blur(28px) saturate(145%);
+    transition: transform 420ms cubic-bezier(0.2, 0.82, 0.2, 1), opacity 240ms ease;
+}
+
+.memory-inspector.open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateX(0);
+}
+
+.memory-inspector-header {
+    display: flex;
+    min-height: 116px;
+    align-items: flex-start;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--line);
+    padding: 24px;
+}
+
+.memory-inspector-header .eyebrow {
+    margin-bottom: 10px;
+}
+
+.memory-inspector-header h2 {
+    font-size: 30px;
+    font-weight: 800;
+    line-height: 1;
+}
+
+.memory-inspector-body {
+    min-height: 0;
+    overflow-y: auto;
+    padding: 24px;
+}
+
+.memory-inspector-meta {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1px;
+    border: 1px solid var(--line);
+    background: var(--line);
+    margin-bottom: 30px;
+}
+
+.memory-inspector-meta > div {
+    min-width: 0;
+    background: color-mix(in srgb, var(--glass) 82%, transparent);
+    padding: 13px;
+}
+
+.memory-inspector-meta dt,
+.memory-editor-label {
+    color: var(--muted);
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 8px;
+}
+
+.memory-inspector-meta dd {
+    overflow: hidden;
+    margin-top: 7px;
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 10px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.memory-editor-label {
+    display: block;
+    margin-bottom: 9px;
+}
+
+.memory-editor {
+    width: 100%;
+    min-height: 300px;
+    resize: vertical;
+    border: 1px solid var(--line-strong);
+    border-radius: 7px;
+    background: rgba(255, 255, 255, 0.34);
+    color: var(--ink);
+    padding: 17px;
+    font-size: 15px;
+    line-height: 1.8;
+    transition: border-color var(--ease), background var(--ease), box-shadow var(--ease);
+}
+
+.memory-editor:focus {
+    border-color: var(--violet);
+    background: var(--glass-strong);
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--violet) 12%, transparent);
+    outline: 0;
+}
+
+.memory-editor-status {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    color: var(--muted);
+    margin-top: 10px;
+    font-size: 10px;
+}
+
+.memory-editor-status strong {
+    color: var(--ink);
+    font-family: "IBM Plex Mono", monospace;
+    font-weight: 500;
+}
+
+.memory-inspector-footer {
+    display: flex;
+    min-height: 78px;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+    border-top: 1px solid var(--line);
+    background: color-mix(in srgb, var(--glass-strong) 80%, transparent);
+    padding: 16px 24px;
+}
+
+.btn:disabled {
+    box-shadow: none;
+    cursor: not-allowed;
+    opacity: 0.46;
+    transform: none;
+}
+
 .modal-content {
     width: min(720px, 100%);
     max-height: min(800px, 90vh);
@@ -1437,12 +1605,20 @@ select.input {
     .filter-station { padding: 17px; }
     .filters-grid { grid-template-columns: 1fr; }
     .ledger-toolbar { align-items: flex-start; flex-direction: column; padding: 10px 12px; }
+    .selection-tools { width: 100%; align-items: flex-start; flex-direction: column; }
+    .batch-actions { width: 100%; }
     .memory-item { grid-template-columns: 28px minmax(0, 1fr); padding-right: 12px; padding-left: 8px; }
     .memory-actions { grid-column: 2; flex-direction: row; }
     .memory-header { align-items: flex-start; flex-direction: column; gap: 4px; }
     .memory-session { max-width: 72vw; }
     .detail-item { grid-template-columns: 1fr; gap: 5px; }
     .stat-value { font-size: 40px; }
+    .memory-inspector-header { min-height: 104px; padding: 19px 16px; }
+    .memory-inspector-body { padding: 20px 16px; }
+    .memory-inspector-meta { grid-template-columns: 1fr; }
+    .memory-editor { min-height: 260px; }
+    .memory-inspector-footer { padding: 14px 16px; }
+    .memory-inspector-footer .btn { flex: 1; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/tests/test_memory_service.py
+++ b/tests/test_memory_service.py
@@ -113,7 +113,7 @@ class _UpdateVectorDB:
     def has_collection(self, _collection_name):
         return True
 
-    def query(self, **kwargs):
+    def get_by_id(self, **kwargs):
         record = {
             "session_id": "session-1",
             "content": "原始记忆",
@@ -124,7 +124,7 @@ class _UpdateVectorDB:
             record["memory_id"] = 42
         else:
             record["id"] = "native-42"
-        return [record]
+        return record
 
     def update(self, collection_name, record_id, data):
         self.updated = (collection_name, record_id, data)

--- a/tests/test_memory_service.py
+++ b/tests/test_memory_service.py
@@ -36,7 +36,10 @@ if "astrbot.api" not in sys.modules:
 
 
 from admin_panel.services.memory_service import MemoryService  # noqa: E402
-from memory_manager.vector_db_base import VectorDeleteResult  # noqa: E402
+from memory_manager.vector_db_base import (  # noqa: E402
+    VectorDeleteResult,
+    VectorInsertResult,
+)
 
 
 class _FakeVectorDB:
@@ -88,3 +91,111 @@ async def test_delete_memory_uses_memory_id_for_milvus():
         "memory_collection",
         "memory_id == 123",
     )
+
+
+class _EmbeddingProvider:
+    async def get_embedding(self, text):
+        return [float(len(text)), 0.5]
+
+
+class _UpdateVectorDB:
+    def __init__(self, backend="chroma", fail_first_insert=False):
+        self.backend = backend
+        self.fail_first_insert = fail_first_insert
+        self.updated = None
+        self.deleted_expr = None
+        self.inserted = []
+        self.flushed = False
+
+    def is_connected(self):
+        return True
+
+    def has_collection(self, _collection_name):
+        return True
+
+    def query(self, **kwargs):
+        record = {
+            "session_id": "session-1",
+            "content": "原始记忆",
+            "create_time": 1700000000,
+            "personality_id": "persona-1",
+        }
+        if self.backend == "milvus":
+            record["memory_id"] = 42
+        else:
+            record["id"] = "native-42"
+        return [record]
+
+    def update(self, collection_name, record_id, data):
+        self.updated = (collection_name, record_id, data)
+        return VectorInsertResult(insert_count=1, primary_keys=[record_id])
+
+    def delete(self, collection_name, expr):
+        self.deleted_expr = (collection_name, expr)
+        return VectorDeleteResult(delete_count=1)
+
+    def insert(self, collection_name, data):
+        self.inserted.append((collection_name, data[0]))
+        if self.fail_first_insert and len(self.inserted) == 1:
+            return VectorInsertResult()
+        return VectorInsertResult(
+            insert_count=1,
+            primary_keys=[100 + len(self.inserted)],
+        )
+
+    def flush(self, _collection_names):
+        self.flushed = True
+
+
+class _UpdatePlugin:
+    def __init__(self, backend="chroma", fail_first_insert=False):
+        self.config = {"vector_db_type": backend}
+        self.collection_name = "memory_collection"
+        self.vector_db = _UpdateVectorDB(backend, fail_first_insert)
+        self.embedding_provider = _EmbeddingProvider()
+
+
+@pytest.mark.asyncio
+async def test_update_memory_preserves_native_id_and_regenerates_embedding():
+    plugin = _UpdatePlugin("chroma")
+    service = MemoryService(plugin)
+
+    result = await service.update_memory("native-42", "更新后的记忆")
+
+    assert result["memory_id"] == "native-42"
+    assert result["id_changed"] is False
+    assert result["embedding_regenerated"] is True
+    assert plugin.vector_db.updated[1] == "native-42"
+    assert plugin.vector_db.updated[2]["content"] == "更新后的记忆"
+    assert plugin.vector_db.updated[2]["embedding"] == [6.0, 0.5]
+    assert plugin.vector_db.flushed
+
+
+@pytest.mark.asyncio
+async def test_update_memory_replaces_milvus_auto_id():
+    plugin = _UpdatePlugin("milvus")
+    service = MemoryService(plugin)
+
+    result = await service.update_memory("42", "新的 Milvus 记忆")
+
+    assert plugin.vector_db.deleted_expr == (
+        "memory_collection",
+        "memory_id == 42",
+    )
+    assert result["memory_id"] == "101"
+    assert result["previous_memory_id"] == "42"
+    assert result["id_changed"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_memory_rolls_back_milvus_when_insert_fails():
+    plugin = _UpdatePlugin("milvus", fail_first_insert=True)
+    service = MemoryService(plugin)
+
+    with pytest.raises(RuntimeError, match="原内容已恢复"):
+        await service.update_memory("42", "无法写入的新内容")
+
+    assert len(plugin.vector_db.inserted) == 2
+    rollback_payload = plugin.vector_db.inserted[1][1]
+    assert rollback_payload["content"] == "原始记忆"
+    assert rollback_payload["embedding"] == [4.0, 0.5]

--- a/web_api.py
+++ b/web_api.py
@@ -51,6 +51,7 @@ class MnemosyneWebApi:
         register(f"/{PLUGIN_NAME}/memories/statistics", self.get_memory_statistics, ["GET"], "")
         register(f"/{PLUGIN_NAME}/memories/sessions", self.get_session_list, ["GET"], "")
         register(f"/{PLUGIN_NAME}/memories/delete", self.batch_delete_memories, ["POST"], "")
+        register(f"/{PLUGIN_NAME}/memories/<memory_id>/update", self.update_single_memory, ["POST"], "")
         register(f"/{PLUGIN_NAME}/memories/<memory_id>/delete", self.delete_single_memory, ["POST"], "")
         register(f"/{PLUGIN_NAME}/memories/session/<session_id>/delete", self.delete_session_memories, ["POST"], "")
         register(f"/{PLUGIN_NAME}/memories/export", self.export_memories, ["GET"], "")
@@ -209,6 +210,25 @@ class MnemosyneWebApi:
         except Exception as e:
             logger.error(f"删除记忆失败: {e}", exc_info=True)
             return jsonify(self._error(str(e)))
+
+    async def update_single_memory(self, memory_id: str) -> Any:
+        try:
+            mid = str(memory_id or "").strip()
+            if not mid or not re.fullmatch(r"[a-zA-Z0-9_-]+", mid):
+                return jsonify(self._error("memory_id 格式无效"))
+
+            body = await request.get_json(silent=True) or {}
+            content = body.get("content")
+            if not isinstance(content, str):
+                return jsonify(self._error("content 参数无效"))
+
+            record = await self.memory_service.update_memory(mid, content)
+            return jsonify({"updated": True, "record": record})
+        except (ValueError, RuntimeError) as e:
+            return jsonify(self._error(str(e)))
+        except Exception as e:
+            logger.error(f"更新记忆失败: {e}", exc_info=True)
+            return jsonify(self._error("更新记忆时发生内部错误"))
 
     async def delete_session_memories(self, session_id: str) -> Any:
         try:

--- a/web_api.py
+++ b/web_api.py
@@ -27,6 +27,7 @@ from .core.security_utils import (
 )
 
 PLUGIN_NAME = "astrbot_plugin_mnemosyne"
+MEMORY_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_.:-]+$")
 
 
 class MnemosyneWebApi:
@@ -181,7 +182,7 @@ class MnemosyneWebApi:
                 return jsonify(self._error("memory_ids 参数无效"))
 
             for mid in memory_ids:
-                if not isinstance(mid, str) or not re.match(r"^[a-zA-Z0-9_-]+$", mid):
+                if not isinstance(mid, str) or not MEMORY_ID_PATTERN.fullmatch(mid):
                     return jsonify(self._error(f"memory_id 格式无效: {mid}"))
 
             deleted_count = 0
@@ -201,7 +202,7 @@ class MnemosyneWebApi:
             mid = str(memory_id).strip()
             if not mid:
                 return jsonify(self._error("memory_id 不能为空"))
-            if not re.match(r"^[a-zA-Z0-9_-]+$", mid):
+            if not MEMORY_ID_PATTERN.fullmatch(mid):
                 return jsonify(self._error("memory_id 格式无效"))
             success = await self.memory_service.delete_memory(mid)
             if not success:
@@ -214,7 +215,7 @@ class MnemosyneWebApi:
     async def update_single_memory(self, memory_id: str) -> Any:
         try:
             mid = str(memory_id or "").strip()
-            if not mid or not re.fullmatch(r"[a-zA-Z0-9_-]+", mid):
+            if not mid or not MEMORY_ID_PATTERN.fullmatch(mid):
                 return jsonify(self._error("memory_id 格式无效"))
 
             body = await request.get_json(silent=True) or {}


### PR DESCRIPTION
## Summary

- add a responsive memory inspector with editable content, metadata, character limits, draft state, and selection controls
- regenerate embeddings when memory content changes and refresh the workspace in place
- preserve native IDs through Chroma, Qdrant, and Weaviate update APIs
- handle Milvus AutoID replacement with precomputed rollback data and explicit ID-change responses
- harden the Canvas renderer by stopping offscreen animation, adding teardown, and providing a `roundRect` fallback
- keep all UI icons on Lucide and maintain an emoji-free interface

Closes #115

## Verification

- `python3 -m compileall -q admin_panel memory_manager web_api.py tests/test_memory_service.py`
- `node --check pages/panel/app.js`
- `node --check pages/panel/demo-bridge.js`
- `node --check pages/panel/memory-field.js`
- `git diff --check`
- isolated Python 3.12 test environment: `5 passed` in `tests/test_memory_service.py`
- desktop and 390x844 browser QA
- verified inspector open/edit/save/close workflow, list refresh, responsive sizing, and zero horizontal overflow

## Summary by Sourcery

Introduce an in-panel memory inspector that allows editing individual memories while regenerating their embeddings and keeping the admin workspace responsive and safe.

New Features:
- Add a side-panel memory inspector UI with editable content, metadata display, character limits, and draft status messaging.
- Enable single-memory update via a new web API endpoint and wire it to the admin panel inspector workflow.
- Support batch selection tools in the memory ledger, including select-all and clear-selection actions.

Bug Fixes:
- Prevent the memory field canvas animation from running when offscreen or after the page is torn down, avoiding orphaned event handlers.

Enhancements:
- Extend the memory service to support content updates with embedding regeneration and consistent timestamp/persona/session metadata.
- Implement backend-specific update and lookup paths for Chroma, Qdrant, Weaviate, and Milvus, preserving native IDs where possible and surfacing explicit ID-change information.
- Improve the memory inspector layout and modal behavior for small screens, including scroll handling and disabled button styling.

Tests:
- Add unit tests covering memory update behavior across vector DB backends, including Milvus AutoID replacement and rollback on failed inserts.